### PR TITLE
Re-enables Digi uniforms

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -105,7 +105,7 @@ There are several things that need to be remembered:
 		if((dna?.species.bodytype & BODYTYPE_MONKEY) && (uniform.supports_variations_flags & CLOTHING_MONKEY_VARIATION))
 			icon_file = MONKEY_UNIFORM_FILE
 		else if((dna?.species.bodytype & BODYTYPE_DIGITIGRADE) && (uniform.supports_variations_flags & CLOTHING_DIGITIGRADE_VARIATION))
-			icon_file = DIGITIGRADE_UNIFORM_FILE
+			icon_file = uniform.worn_icon_digi || DIGITIGRADE_UNIFORM_FILE // EFFIGY - RE-ENABLE DIGI OUTFITS
 		//Female sprites have lower priority than digitigrade sprites
 		else if(dna.species.sexes && (dna.species.bodytype & BODYTYPE_HUMANOID) && physique == FEMALE && !(uniform.female_sprite_flags & NO_FEMALE_UNIFORM)) //Agggggggghhhhh
 			woman = TRUE


### PR DESCRIPTION
## About The Pull Request

Like it says above. This will let digi outfit variations work again since they were apparently disabled.

## Why It's Good For The Game

Cause having broken sprites is super dumb.

## Changelog
:cl:
fix: re-enabled digi uniform variants.
/:cl:

