### PR TITLE
It takes two players for

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -600,6 +600,8 @@
 	default = -1
 	min_val = 0
 
+/datum/config_entry/flag/setup_bypass_player_check
+
 /datum/config_entry/string/default_view
 	default = "15x15"
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -16,6 +16,8 @@ SUBSYSTEM_DEF(ticker)
 	var/start_immediately = FALSE
 	/// Boolean to track and check if our subsystem setup is done.
 	var/setup_done = FALSE
+	/// Did we broadcast at players to hurry up?
+	var/delay_notified = FALSE
 
 	var/datum/game_mode/mode = null
 
@@ -179,15 +181,25 @@ SUBSYSTEM_DEF(ticker)
 
 			if(start_immediately)
 				timeLeft = 0
+				CONFIG_SET(flag/setup_bypass_player_check, TRUE)
 
 			//countdown
-			if(timeLeft < 0)
-				return
+			if(timeLeft < 0 && CONFIG_GET(flag/setup_bypass_player_check))
+				return // 'DELAYED' delayed by an admin
 			timeLeft -= wait
 
 			if(timeLeft <= 450 && !tipped) // EFFIGY EDIT CHANGE
 				send_tip_of_the_round(world, selected_tip)
 				tipped = TRUE
+
+			if(timeLeft <= 0 && !CONFIG_GET(flag/setup_bypass_player_check) && !totalPlayersReady)
+				if(!delay_notified)
+					to_chat(world, "[span_boxannounceorange("Game setup delayed! The game will start when players are ready.")]", confidential = TRUE)
+					SEND_SOUND(world, sound('sound/ai/default/attention.ogg'))
+					message_admins("Game setup delayed due to lack of players.")
+					log_game("Game setup delayed due to lack of players.")
+					delay_notified = TRUE
+				return // 'SOON' waiting for players
 
 			if(timeLeft <= 0)
 				SEND_SIGNAL(src, COMSIG_TICKER_ENTER_SETTING_UP)

--- a/code/modules/admin/verbs/server.dm
+++ b/code/modules/admin/verbs/server.dm
@@ -206,6 +206,7 @@
 		return tgui_alert(usr, "Too late... The game has already started!")
 	if(newtime)
 		newtime = newtime*10
+		CONFIG_SET(flag/setup_bypass_player_check, TRUE)
 		SSticker.SetTimeLeft(newtime)
 		SSticker.start_immediately = FALSE
 		if(newtime < 0)

--- a/config/config.txt
+++ b/config/config.txt
@@ -546,6 +546,8 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 ## Uncomment to set the number of /world/Reboot()s before the DreamDaemon restarts itself. 0 means restart every round. Requires tgstation server tools.
 #ROUNDS_UNTIL_HARD_RESTART 10
 
+## Uncomment to disable waiting for players before proceeding to game setup.
+#SETUP_BYPASS_PLAYER_CHECK
 
 ##Default view size, in tiles.
 ##	By default, this is 15x15, which gets simplified to 7 by byond


### PR DESCRIPTION
## About The Pull Request

Pre-game lobby doesn't proceed to setup until there are players connected and ready. Can be overridden in config and with the admin commands Delay Pre-Game and Start-Now.

## Why It's Good For The Game

- No point in starting the processing if nobody is around to play.
- If a server is empty for whatever reason before a player connects, they aren't greeted with a game that's been running for hours, no power, air depleted etc.

https://user-images.githubusercontent.com/83487515/236703589-b67cb2b0-4695-45cb-bac2-f879702eb159.mp4

## Changelog

:cl: LT3
config: Round will wait in the pre-game lobby if nobody is flagged ready
/:cl: