### PR TITLE
Engi borg Painting tool expansion

### DIFF
--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -150,15 +150,6 @@
 		to_chat(user, span_notice("You remove [ink] from [src]."))
 		ink = null
 
-/obj/item/airlock_painter/cyborg
-	name = "industrial airlock painter"
-	desc = "An industry standard mechanized airlock painter"
-	icon = 'icons/obj/objects.dmi'
-	icon_state = "paint_sprayer"
-	inhand_icon_state = "paint_sprayer"
-	worn_icon_state = "painter"
-
-
 /obj/item/airlock_painter/decal
 	name = "decal painter"
 	desc = "An airlock painter, reprogramed to use a different style of paint in order to apply decals for floor tiles as well, in addition to repainting doors. Decals break when the floor tiles are removed."

--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -158,6 +158,7 @@
 	inhand_icon_state = "paint_sprayer"
 	worn_icon_state = "painter"
 
+
 /obj/item/airlock_painter/decal
 	name = "decal painter"
 	desc = "An airlock painter, reprogramed to use a different style of paint in order to apply decals for floor tiles as well, in addition to repainting doors. Decals break when the floor tiles are removed."
@@ -376,6 +377,23 @@
 				insert_state(decal[2], dir[2], "custom")
 
 	qdel(painter)
+
+//EFFIGY ADDITION - START
+/obj/item/airlock_painter/decal/cyborg
+	name = "cyborg decal painter"
+	desc = "A mechnically installed painter with molecular printer to supply any and all of a painter's needs!"
+	desc_controls = ""
+
+/obj/item/airlock_painter/decal/cyborg/use_paint(mob/user)
+	if(can_use(user))
+		playsound(src.loc, 'sound/effects/spray2.ogg', 50, TRUE)
+		return TRUE
+	else
+		return FALSE
+
+/obj/item/airlock_painter/decal/cyborg/AltClick(mob/user)
+	return
+//EFFIGY ADDITION - END
 
 /obj/item/airlock_painter/decal/debug
 	name = "extreme decal painter"

--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -150,6 +150,14 @@
 		to_chat(user, span_notice("You remove [ink] from [src]."))
 		ink = null
 
+/obj/item/airlock_painter/cyborg
+	name = "industrial airlock painter"
+	desc = "An industry standard mechanized airlock painter"
+	icon = 'icons/obj/objects.dmi'
+	icon_state = "paint_sprayer"
+	inhand_icon_state = "paint_sprayer"
+	worn_icon_state = "painter"
+
 /obj/item/airlock_painter/decal
 	name = "decal painter"
 	desc = "An airlock painter, reprogramed to use a different style of paint in order to apply decals for floor tiles as well, in addition to repainting doors. Decals break when the floor tiles are removed."

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -372,7 +372,8 @@
 		/obj/item/stack/rods/cyborg,
 		/obj/item/stack/tile/iron/base/cyborg,
 		/obj/item/stack/cable_coil,
-		/obj/item/airlock_painter/cyborg,
+		//EFFIGY ADDITION - Adds cyborg painter
+		/obj/item/airlock_painter/decal/cyborg,
 	)
 	radio_channels = list(RADIO_CHANNEL_ENGINEERING)
 	emag_modules = list(

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -372,6 +372,7 @@
 		/obj/item/stack/rods/cyborg,
 		/obj/item/stack/tile/iron/base/cyborg,
 		/obj/item/stack/cable_coil,
+		/obj/item/airlock_painter/cyborg,
 	)
 	radio_channels = list(RADIO_CHANNEL_ENGINEERING)
 	emag_modules = list(


### PR DESCRIPTION
## About The Pull Request

Was a request by a borg player on the dicord. Seemed to make enough sense for an engineer borg to be able to paint doors and floors.  So here it is.
I kind of winged it on the flavor text though, so feel free to change that up if you have something better in mind.

## Why It's Good For The Game

More tools for el' borgos.

## Changelog

:cl:
add: New cyborg painting tool assigned to engineering borgs.
/:cl:
