### PR TITLE
Ministation drobes

### DIFF
--- a/_maps/map_files/MiniStation/MiniStation.dmm
+++ b/_maps/map_files/MiniStation/MiniStation.dmm
@@ -90,15 +90,14 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/table,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 1
 	},
-/obj/item/clothing/head/soft,
 /obj/machinery/light/directional/north,
 /obj/machinery/status_display/supply{
 	pixel_y = 32
 	},
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ao" = (
@@ -1990,10 +1989,10 @@
 /area/station/security/brig)
 "eX" = (
 /obj/machinery/requests_console{
-	department = "Security";
-	pixel_y = 30;
+	anon_tips_receiver = 1;
 	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	department = "Security";
+	pixel_y = 30
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -4841,11 +4840,11 @@
 /obj/item/disk/tech_disk,
 /obj/machinery/requests_console/directional/east{
 	announcementConsole = 1;
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
 	department = "Research Lab";
 	name = "Research Requests Console";
-	receive_ore_updates = 1;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	receive_ore_updates = 1
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -6208,11 +6207,11 @@
 	},
 /obj/item/assembly/timer,
 /obj/machinery/requests_console/directional/west{
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
 	department = "Ordnance Lab";
 	name = "Toxins Requests Console";
-	pixel_x = 30;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	pixel_x = 30
 	},
 /turf/open/floor/iron,
 /area/station/science/research)
@@ -7676,11 +7675,11 @@
 "sX" = (
 /obj/machinery/requests_console/directional/west{
 	announcementConsole = 1;
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
 	department = "Chief Medical Officer's Desk";
 	name = "Chief Medical Officer's Requests Console";
-	pixel_x = 30;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	pixel_x = 30
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -11801,8 +11800,8 @@
 /area/station/maintenance/port)
 "Di" = (
 /obj/machinery/conveyor{
-	id = "recycler";
-	dir = 6
+	dir = 6;
+	id = "recycler"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
@@ -11968,9 +11967,9 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/servo,
 /obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/servo,
 /obj/machinery/camera/directional/east{
 	c_tag = "Science Research";
 	network = list("ss13","rd")
@@ -11986,10 +11985,10 @@
 /obj/item/target/clown,
 /obj/item/target/alien,
 /obj/machinery/requests_console/directional/west{
-	department = "Ordnance Test Range";
-	name = "Test Range Requests Console";
+	anon_tips_receiver = 1;
 	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	department = "Ordnance Test Range";
+	name = "Test Range Requests Console"
 	},
 /obj/machinery/camera/directional/south{
 	c_tag = "Science Toxins Test Lab";
@@ -12964,10 +12963,10 @@
 "Gk" = (
 /obj/machinery/requests_console/directional/west{
 	announcementConsole = 1;
-	department = "Head of Personnel's Desk";
-	name = "Head of Personnel's Requests Console";
+	anon_tips_receiver = 1;
 	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	department = "Head of Personnel's Desk";
+	name = "Head of Personnel's Requests Console"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13561,10 +13560,10 @@
 	},
 /obj/machinery/requests_console/directional/east{
 	announcementConsole = 1;
-	department = "Bridge";
-	name = "Bridge Requests Console";
+	anon_tips_receiver = 1;
 	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	department = "Bridge";
+	name = "Bridge Requests Console"
 	},
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
@@ -17741,7 +17740,7 @@
 /area/station/medical/medbay/central)
 "YK" = (
 /obj/machinery/airalarm/directional/north,
-/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "YL" = (
@@ -17825,10 +17824,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "Zc" = (
-/obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/vending/wardrobe/engi_wardrobe,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "Zd" = (


### PR DESCRIPTION

## About The Pull Request
Adds cargo, engi, and atmos drobes to Ministation. Replaces a table, an emergency locker, and an electrical locker respectively.
## Why It's Good For The Game
Cargodrobe provides mailbags, and engidrobe provides several useful items such as welding hard hats. Atmosdrobe is really only there to round out the engidrobe, but there's already an electrical supplies locker and a stack of insulated gloves in the department, so I doubt the replaced locker will be missed.
## Changelog
:cl:
add: Added engi, atmos, and cargo Drobes to Ministation.
/:cl:
