### PR TITLE
Autotransfer uses time from ticker

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -285,7 +285,7 @@ SUBSYSTEM_DEF(ticker)
 
 	round_start_time = world.time //otherwise round_start_time would be 0 for the signals
 	round_start_real_time = REALTIMEOFDAY // EFFIGY EDIT ADD - STATPANEL
-	SSautotransfer.new_shift()
+	SSautotransfer.new_shift(round_start_real_time)
 	SEND_SIGNAL(src, COMSIG_TICKER_ROUND_STARTING, world.time)
 
 	log_world("Game start took [(world.timeofday - init_start)/10]s")

--- a/packages/autotransfer/autotransfer.dm
+++ b/packages/autotransfer/autotransfer.dm
@@ -48,11 +48,11 @@ SUBSYSTEM_DEF(autotransfer)
 	else
 		SSshuttle.autoEnd()
 
-/datum/controller/subsystem/autotransfer/proc/new_shift()
+/datum/controller/subsystem/autotransfer/proc/new_shift(round_start_real_time)
 	var/init_vote = CONFIG_GET(number/vote_autotransfer_initial)
-	starttime = REALTIMEOFDAY
+	starttime = round_start_real_time
 	targettime = starttime + init_vote
-	log_game("Autotransfer enabled, first vote in [time2text(targettime - REALTIMEOFDAY)]")
-	message_admins("Autotransfer enabled, first vote in [time2text(targettime - REALTIMEOFDAY)]")
+	//log_game("Autotransfer enabled, first vote in [time2text(targettime - starttime)]")
+	//message_admins("Autotransfer enabled, first vote in [time2text(targettime - starttime)]")
 
 #undef NO_MAXVOTES_CAP


### PR DESCRIPTION
:cl: LT3
fix: Autotransfer vote should not fire immediately after a delayed round start
/:cl: