### PR TITLE
Nicotine withdrawal nerf

### DIFF
--- a/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -262,6 +262,7 @@
 	QDEL_NULL(fake_alert_ref)
 	QDEL_NULL(health_doll_ref)
 
+/*EFFIGY EDIT START - Removes Shakes and Cough emotes from nicotine withdrawal.
 ///Nicotine
 /datum/addiction/nicotine
 	name = "nicotine"
@@ -270,6 +271,7 @@
 
 	medium_withdrawal_moodlet = /datum/mood_event/nicotine_withdrawal_moderate
 	severe_withdrawal_moodlet = /datum/mood_event/nicotine_withdrawal_severe
+
 
 /datum/addiction/nicotine/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon, seconds_per_tick)
 	. = ..()
@@ -286,3 +288,4 @@
 	affected_carbon.set_jitter_if_lower(30 SECONDS * seconds_per_tick)
 	if(SPT_PROB(15, seconds_per_tick))
 		affected_carbon.emote("cough")
+EFFIGY EDIT END */

--- a/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -262,7 +262,7 @@
 	QDEL_NULL(fake_alert_ref)
 	QDEL_NULL(health_doll_ref)
 
-/*EFFIGY EDIT START - Removes Shakes and Cough emotes from nicotine withdrawal.
+/*EFFIGY CHANGE - Moved to overrides
 ///Nicotine
 /datum/addiction/nicotine
 	name = "nicotine"

--- a/overrides/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/overrides/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -6,14 +6,15 @@
 	medium_withdrawal_moodlet = /datum/mood_event/nicotine_withdrawal_moderate
 	severe_withdrawal_moodlet = /datum/mood_event/nicotine_withdrawal_severe
 
+// EFFIGY EDIT START - Alters nicotine Withdrawal
 /datum/addiction/nicotine/proc/trigger_random_side_effect(mob/living/carbon/affected_carbon, seconds_per_tick, strength)
 	switch(rand(1, 10))
-		if(1 to 3)
+		if(1 to 4)
 			if(!HAS_TRAIT(affected_carbon, TRAIT_NOHUNGER))
 				affected_carbon.adjust_nutrition(-seconds_per_tick * 10 * strength)
-		if(3 to 5)
-			affected_carbon.emote("cough")
-		if(5 to 7)
+//		if(3 to 5)
+//			affected_carbon.emote("cough")
+		if(4 to 7)
 			to_chat(affected_carbon, span_warning("Your head hurts."))
 			affected_carbon.adjustStaminaLoss(4 * strength)
 		if(8)
@@ -24,17 +25,18 @@
 			to_chat(affected_carbon, span_warning("You feel tired."))
 			affected_carbon.adjustStaminaLoss(6 * strength)
 
+
 /datum/addiction/nicotine/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon, seconds_per_tick)
 	. = ..()
-	affected_carbon.set_jitter_if_lower(10 SECONDS)
+	// affected_carbon.set_jitter_if_lower(10 SECONDS)
 
 /datum/addiction/nicotine/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon, seconds_per_tick)
 	. = ..()
-	affected_carbon.set_jitter_if_lower(20 SECONDS)
+	// affected_carbon.set_jitter_if_lower(20 SECONDS)
 
 /datum/addiction/nicotine/withdrawal_enters_stage_3(mob/living/carbon/affected_carbon, seconds_per_tick)
 	. = ..()
-	affected_carbon.set_jitter_if_lower(30 SECONDS)
+	// affected_carbon.set_jitter_if_lower(30 SECONDS)
 
 /datum/addiction/nicotine/withdrawal_stage_2_process(mob/living/carbon/affected_carbon, seconds_per_tick)
 	. = ..()
@@ -45,3 +47,5 @@
 	. = ..()
 	if(SPT_PROB(5, seconds_per_tick))
 		trigger_random_side_effect(affected_carbon, seconds_per_tick, 2)
+
+	//EFFIGY EDIT END

--- a/overrides/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/overrides/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -9,7 +9,7 @@
 // EFFIGY EDIT START - Alters nicotine Withdrawal
 /datum/addiction/nicotine/proc/trigger_random_side_effect(mob/living/carbon/affected_carbon, seconds_per_tick, strength)
 	switch(rand(1, 10))
-		if(1 to 4)
+		if(1 to 3)
 			if(!HAS_TRAIT(affected_carbon, TRAIT_NOHUNGER))
 				affected_carbon.adjust_nutrition(-seconds_per_tick * 10 * strength)
 //		if(3 to 5)


### PR DESCRIPTION
## About The Pull Request

Nerfs the withdrawal effects of nicotine.
I know I've bitched about this for years but here it finally is.
To address an Effigy specific issue, I've blocked out the old code in favor of the override code. Turns out we were actually double-dipping on the side effects and coughing. Explains why earlier, I had mentioned during a live round how I had like 20 coughs in a handful of seconds.
![image](https://github.com/effigy-se/effigy-se/assets/84706993/21c4c2f4-5941-4b39-b2ac-5dc2f5ebd996)


Additionally, I've straight up removed the coughing and the jitteriness from the remaining version.
However, gives a slight buff to the chance of getting hit with the stamina loss side effects.

## Why It's Good For The Game

Well for an RP server, it's just annoying. When I or others who use smokes stop for an RP scene you end up clogging up the chat log with "So-n-So coughs" messages. Additionally, the jitteriness fucks with layering and such, making some scenes wonk out. I feel the mood debuff(Which affects your speed) and the other side effects are pretty much mechanically punishing enough and don't really damage the RP side of things.

Additionally, just for a realistic perspective. I've known plenty of smokers in my life. I have yet to see one not smoke for a minute and start having convulsions and coughing up a storm.

Even if we don't take the full thing. At least killing the double-dip should be done.

## Changelog

:cl:
balance: Nerfed smoking withdrawal side effects.
code: fixed bug causing Nicotine side effects to hit twice as often.
/:cl:


