### PR TITLE
Foxhole And The Signening

### DIFF
--- a/_maps/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/map_files/FoxHoleStation/foxholestation.dmm
@@ -4733,6 +4733,25 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/cargo/storage)
+"cMc" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/sign/directions/science/directional/north{
+	pixel_y = 42;
+	dir = 8
+	},
+/obj/structure/sign/directions/security/directional/north{
+	pixel_y = 36;
+	dir = 8
+	},
+/obj/structure/sign/directions/arrival/directional/north{
+	pixel_y = 30;
+	dir = 8
+	},
+/obj/structure/sign/directions/dorms/directional/north{
+	pixel_y = 24
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "cMD" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 8
@@ -9889,6 +9908,16 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/medical/treatment_center)
+"fTf" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "fTn" = (
 /obj/machinery/door/firedoor,
 /obj/structure/railing{
@@ -13669,6 +13698,23 @@
 "ihh" = (
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"ihL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/sign/directions/arrival/directional/east{
+	dir = 8;
+	pixel_y = 10
+	},
+/obj/structure/sign/directions/supply/directional/east{
+	pixel_y = 4
+	},
+/obj/structure/sign/directions/engineering/directional/east{
+	pixel_y = -2
+	},
+/obj/structure/sign/directions/medical/directional/east{
+	pixel_y = -8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "iio" = (
 /obj/structure/cable,
 /obj/machinery/computer/order_console/cook{
@@ -15990,6 +16036,15 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/commons)
+"jCa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "jCz" = (
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
@@ -19061,6 +19116,19 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos)
+"lyd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/departments/holy/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "lyt" = (
 /obj/structure/disposalpipe/trunk/multiz{
 	dir = 1
@@ -20461,6 +20529,11 @@
 	},
 /turf/open/floor/iron/smooth_half,
 /area/station/ai_monitored/turret_protected/aisat/service)
+"mrg" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/sign/directions/command/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "mrh" = (
 /obj/effect/baseturf_helper/reinforced_plating/ceiling,
 /turf/closed/wall,
@@ -20702,6 +20775,7 @@
 /area/station/engineering/main)
 "myL" = (
 /obj/machinery/airalarm/directional/west,
+/obj/structure/sign/departments/maint/alt/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "myP" = (
@@ -24740,6 +24814,7 @@
 	pixel_x = -5;
 	pixel_y = 1
 	},
+/obj/structure/sign/xenobio_guide/directional/west,
 /turf/open/floor/iron/white/diagonal,
 /area/station/science/xenobiology)
 "pfh" = (
@@ -25219,6 +25294,19 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/iron/textured_large,
 /area/station/medical/chemistry)
+"pub" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/sign/departments/restroom/directional/south,
+/turf/open/floor/iron,
+/area/station/commons)
 "pux" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/misc/asteroid,
@@ -25624,6 +25712,7 @@
 /obj/effect/turf_decal/trimline/dark_blue/end{
 	dir = 1
 	},
+/obj/structure/sign/departments/maint/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "pEX" = (
@@ -26853,6 +26942,28 @@
 "qsE" = (
 /turf/open/floor/glass/reinforced,
 /area/station/maintenance/aft/lesser)
+"qsV" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/sign/directions/science/directional/east{
+	pixel_y = 10;
+	dir = 2
+	},
+/obj/structure/sign/directions/security/directional/east{
+	pixel_y = 4;
+	dir = 2
+	},
+/obj/structure/sign/directions/engineering/directional/east{
+	pixel_y = -2;
+	dir = 2
+	},
+/obj/structure/sign/directions/supply/directional/east{
+	pixel_y = -8;
+	dir = 2
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "qsW" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
 	dir = 4
@@ -28042,6 +28153,27 @@
 	dir = 4
 	},
 /area/station/medical/chemistry)
+"raF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/sign/directions/arrival/directional/west{
+	dir = 2;
+	pixel_y = 10
+	},
+/obj/structure/sign/directions/medical/directional/west{
+	pixel_y = 4;
+	dir = 2
+	},
+/obj/structure/sign/directions/evac/directional/west{
+	pixel_y = -2
+	},
+/obj/structure/sign/directions/upload/directional/west{
+	pixel_y = -8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "raQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30560,6 +30692,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/sign/directions/dorms/directional/west,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -30772,6 +30905,18 @@
 	},
 /obj/effect/turf_decal/plaque{
 	icon_state = "L1"
+	},
+/obj/structure/sign/directions/evac/directional/north{
+	pixel_y = 36
+	},
+/obj/structure/sign/directions/command/directional/north{
+	pixel_y = 42
+	},
+/obj/structure/sign/directions/upload/directional/north{
+	pixel_y = 30
+	},
+/obj/structure/sign/directions/vault/directional/north{
+	pixel_y = 24
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -33290,7 +33435,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/east,
-/obj/effect/mapping_helpers/airalarm/tlv_cold_room,
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /obj/effect/mapping_helpers/airalarm/engine_access,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
@@ -35506,7 +35651,7 @@
 /turf/open/floor/iron/dark/corner,
 /area/station/service/hydroponics)
 "vjQ" = (
-/obj/machinery/light/directional/south,
+/obj/structure/sign/departments/evac/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "vjS" = (
@@ -36007,6 +36152,13 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/sign/directions/command/directional/east{
+	pixel_y = 6
+	},
+/obj/structure/sign/directions/upload/directional/east,
+/obj/structure/sign/directions/vault/directional/east{
+	pixel_y = -6
+	},
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -66642,7 +66794,7 @@ dkz
 tPw
 rcq
 fga
-efq
+ihL
 lqa
 bhT
 pBr
@@ -69706,7 +69858,7 @@ uGP
 bTz
 rCA
 rCA
-rCA
+jCa
 rCA
 rCA
 uBG
@@ -69962,7 +70114,7 @@ rnH
 uMk
 seP
 xYT
-oLg
+qsV
 yhI
 yhI
 yhI
@@ -70241,7 +70393,7 @@ xgl
 xgl
 uCt
 uCt
-bHo
+mrg
 dnA
 sxK
 qIf
@@ -75100,7 +75252,7 @@ nBj
 lGX
 lGX
 swf
-mKe
+lyd
 mWp
 nNl
 upV
@@ -75381,7 +75533,7 @@ nKT
 dxu
 dxu
 dxu
-bHo
+cMc
 jWh
 ncp
 dIE
@@ -75616,7 +75768,7 @@ eFK
 eFK
 nTE
 uoX
-pwS
+raF
 xxT
 bHo
 sEJ
@@ -78679,7 +78831,7 @@ sYf
 vUN
 vUN
 vUN
-cUW
+fTf
 vjQ
 jYS
 eFK
@@ -125464,7 +125616,7 @@ sfO
 bns
 sfO
 aUx
-oHe
+pub
 hkD
 hkD
 hkD


### PR DESCRIPTION
Scatters some directional signs around FoxHole, because 99.9% Of Spacemen Fail The Navigate Verb Test (LOWER RESULT RATES THAN ECTO SNIFFERS?? ALMOST DIED AT 3 AM)

:cl:
qol: Foxhole has received navigational signs.
/:cl:
