### PR TITLE
Reverts Multi-Z Performance Mode (+ Accidental Foxhole Updates)

### DIFF
--- a/_maps/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/map_files/FoxHoleStation/foxholestation.dmm
@@ -11412,6 +11412,7 @@
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
 	},
+/obj/item/paper_bin,
 /turf/open/floor/iron/dark,
 /area/station/service/library/private)
 "gPY" = (
@@ -19150,6 +19151,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/item/paper_bin,
 /turf/open/floor/carpet/purple,
 /area/station/service/library/private)
 "lyM" = (
@@ -39165,6 +39167,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"xfn" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/turf/open/floor/wood/large,
+/area/station/service/library/private)
 "xfu" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -70624,7 +70636,7 @@ soR
 cal
 bni
 dMV
-uAY
+xfn
 qfo
 vPC
 sDs

--- a/_maps/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/map_files/FoxHoleStation/foxholestation.dmm
@@ -13740,6 +13740,7 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/plastitanium,
 /area/station/science/robotics)
 "iiN" = (
@@ -38148,6 +38149,7 @@
 /obj/item/clothing/suit/apron/surgical,
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/gloves/latex,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},

--- a/code/modules/client/preferences/multiz_performance.dm
+++ b/code/modules/client/preferences/multiz_performance.dm
@@ -4,15 +4,11 @@
 	savefile_key = "multiz_performance"
 	savefile_identifier = PREFERENCE_PLAYER
 
-	// EFFIGY EDIT CHANGE START
-	// minimum = MULTIZ_PERFORMANCE_DISABLE
-	// maximum = MAX_EXPECTED_Z_DEPTH - 1
-	minimum = 0
-	maximum = 0
-	// EFFIGY EDIT CHANGE END
+	minimum = MULTIZ_PERFORMANCE_DISABLE
+	maximum = MAX_EXPECTED_Z_DEPTH - 1
 
 /datum/preference/numeric/multiz_performance/create_default_value()
-	return 0 // EFFIGY EDIT CHANGE - Original -1
+	return -1
 
 /datum/preference/numeric/multiz_performance/apply_to_client(client/client, value)
 	// Update the plane master group's layering

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/multiz_performance.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/multiz_performance.tsx
@@ -1,9 +1,13 @@
 import { createDropdownInput, Feature } from '../base';
 
 export const multiz_performance: Feature<number> = {
-  name: 'Multi-Z Performance Rendering',
+  name: 'Multi-Z Detail',
   category: 'GAMEPLAY',
+  description: 'How detailed multi-z is. Lower this to improve performance',
   component: createDropdownInput({
-    0: 'Enabled',
+    [-1]: 'Standard',
+    2: 'High',
+    1: 'Medium',
+    0: 'Low',
   }),
 };


### PR DESCRIPTION
Multi-Z Performance mode entirely disables depth perception, which kind of is ***really bad*** for gameplay purposes
LT3 said they'd revert this, they got busy, I've been sitting not busy, thus, logically, I must discord `/tenor thanos fine I'll do it myself` and waste another good branch/commit name

See #213 for the bug this change was originally done for. The only thing having this re-enabled blocks is multi-z ocean maps at the moment, and we have none to speak of.