### PR TITLE
[REQ] Disables Tot/Ling Primary Objective Assassination, Obsessed

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -778,7 +778,7 @@
 	)
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
-	weight = 0 // EFFIGY EDIT #???16 - Obsession is cringe. Original: 4
+	weight = 0 // EFFIGY EDIT #228 - Obsession is cringe. Original: 4
 	cost = 3 // Doesn't have the same impact on rounds as revenants, dragons, sentient disease (10) or syndicate infiltrators (5).
 	repeatable = TRUE
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -778,7 +778,7 @@
 	)
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
-	weight = 4
+	weight = 0 // EFFIGY EDIT #???16 - Obsession is cringe. Original: 4
 	cost = 3 // Doesn't have the same impact on rounds as revenants, dragons, sentient disease (10) or syndicate infiltrators (5).
 	repeatable = TRUE
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -682,7 +682,7 @@
 		destroy_objective.find_target()
 		objectives += destroy_objective
 	else
-		if(prob(0)) // EFFIGY EDIT - #???16 Removes krilling til we sort out how to handle it. Original: 70
+		if(prob(0)) // EFFIGY EDIT - #228 Removes krilling til we sort out how to handle it. Original: 70
 			var/datum/objective/assassinate/kill_objective = new
 			kill_objective.owner = owner
 			kill_objective.find_target()

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -682,7 +682,7 @@
 		destroy_objective.find_target()
 		objectives += destroy_objective
 	else
-		if(prob(70))
+		if(prob(0)) // EFFIGY EDIT - #???16 Removes krilling til we sort out how to handle it. Original: 70
 			var/datum/objective/assassinate/kill_objective = new
 			kill_objective.owner = owner
 			kill_objective.find_target()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -220,7 +220,7 @@
 	objectives += ending_objective
 
 /datum/antagonist/traitor/proc/forge_single_generic_objective()
-	if(prob(0)) // EFFIGY EDIT #???16 - Disables Krilling until we sort out how to best handle it. Original - KILL_PROB
+	if(prob(0)) // EFFIGY EDIT #228 - Disables Krilling until we sort out how to best handle it. Original - KILL_PROB
 		var/list/active_ais = active_ais()
 		if(active_ais.len && prob(DESTROY_AI_PROB(GLOB.joined_player_list.len)))
 			var/datum/objective/destroy/destroy_objective = new()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -220,7 +220,7 @@
 	objectives += ending_objective
 
 /datum/antagonist/traitor/proc/forge_single_generic_objective()
-	if(prob(KILL_PROB))
+	if(prob(0)) // EFFIGY EDIT #???16 - Disables Krilling until we sort out how to best handle it. Original - KILL_PROB
 		var/list/active_ais = active_ais()
 		if(active_ais.len && prob(DESTROY_AI_PROB(GLOB.joined_player_list.len)))
 			var/datum/objective/destroy/destroy_objective = new()

--- a/code/modules/events/creep_awakening.dm
+++ b/code/modules/events/creep_awakening.dm
@@ -1,3 +1,4 @@
+/* /// EFFIGY EDIT REMOVAL - #???16 - Obsession kinda lame tbh
 /datum/round_event_control/obsessed
 	name = "Obsession Awakening"
 	typepath = /datum/round_event/obsessed
@@ -24,3 +25,4 @@
 		H.gain_trauma(/datum/brain_trauma/special/obsessed)
 		announce_to_ghosts(H)
 		break
+*/

--- a/code/modules/events/creep_awakening.dm
+++ b/code/modules/events/creep_awakening.dm
@@ -1,4 +1,4 @@
-/* /// EFFIGY EDIT REMOVAL - #???16 - Obsession kinda lame tbh
+/* /// EFFIGY EDIT REMOVAL - #228 - Obsession kinda lame tbh
 /datum/round_event_control/obsessed
 	name = "Obsession Awakening"
 	typepath = /datum/round_event/obsessed


### PR DESCRIPTION
:cl:
del: Obsessed has been disabled, minus admin fuckery.
del: Traitors/Lings will no longer get full assassination objectives. Progtot can still roll secondary assassinations.
/:cl:
