### PR TITLE
Interactions Menu modernization

### DIFF
--- a/tgui/packages/tgui/interfaces/InteractionMenu.tsx
+++ b/tgui/packages/tgui/interfaces/InteractionMenu.tsx
@@ -1,5 +1,5 @@
 import { useBackend } from '../backend';
-import { Button, NoticeBox, Section, Icon, Box, Stack } from '../components';
+import { Button, Collapsible, Icon, NoticeBox, Section, Stack, Box } from '../components';
 import { Window } from '../layouts';
 
 class Interaction {
@@ -22,7 +22,7 @@ class LewdSlot {
 export const InteractionMenu = (props, context) => {
   const { act, data } = useBackend<Interaction>(context);
   const {
-    categories,
+    categories = [],
     interactions,
     descriptions,
     colors,
@@ -34,38 +34,44 @@ export const InteractionMenu = (props, context) => {
   } = data;
 
   return (
-    <Window width={400} height={600} title={'Interact - ' + self}>
+    <Window width={500} height={600} title={'Interact - ' + self}>
       <Window.Content scrollable>
         {(block_interact && <NoticeBox>Unable to Interact</NoticeBox>) || (
           <NoticeBox>Able to Interact</NoticeBox>
         )}
-        <Section key="interactions">
-          {categories.map((category) => (
-            <Section key={category} title={category}>
-              {interactions[category].map((interaction) => (
-                <Section key={interaction}>
-                  <Button
-                    margin={0}
-                    padding={0}
-                    disabled={block_interact}
-                    color={block_interact ? 'grey' : colors[interaction]}
-                    content={interaction}
-                    icon="exclamation-circle"
-                    onClick={() =>
-                      act('interact', {
-                        interaction: interaction,
-                        selfref: ref_self,
-                        userref: ref_user,
-                      })
-                    }
-                  />
-                  <br />
-                  {descriptions[interaction]}
+        <Stack fill vertical>
+          <Section key="interactions">
+            {categories.map((category) => (
+              <Collapsible key={category} title={category}>
+                <Section fill vertical>
+                  <Box mt={0.2} grow>
+                    {interactions[category].map((interaction) => (
+                      <Button
+                        key={interaction}
+                        margin={0}
+                        padding={0}
+                        width="150.5px"
+                        lineHeight={1.75}
+                        disabled={block_interact}
+                        color={block_interact ? 'grey' : colors[interaction]}
+                        content={interaction}
+                        tooltip={descriptions[interaction]}
+                        icon="exclamation-circle"
+                        onClick={() =>
+                          act('interact', {
+                            interaction: interaction,
+                            selfref: ref_self,
+                            userref: ref_user,
+                          })
+                        }
+                      />
+                    ))}
+                  </Box>
                 </Section>
-              ))}
-            </Section>
-          ))}
-        </Section>
+              </Collapsible>
+            ))}
+          </Section>
+        </Stack>
         {lewd_slots.length > 0 ? (
           <Section key="item_slots" title={'Lewd Slots'}>
             <Stack fill>


### PR DESCRIPTION
Part 1, i need to recategorize  the verbs themselves next and then move onto officially adding more
## About The Pull Request

I dont like having to scroll a mile to just accidentally sit on someone's face, this categorizes everything and shrinks them down into manigable categories based on the action. This screenshot isnt final for categories, just an example.

![image](https://github.com/effigy-se/effigy-se/assets/22140677/f86161d1-f255-4f7e-8c58-487e48877126)


## Why It's Good For The Game

Secks

## Changelog
:cl:
qol: makes lewding verbs not be a CVS receipt
/:cl:
