### PR TITLE
Updates airlock assembly sprites

### DIFF
--- a/code/modules/asset_cache/assets/rcd.dm
+++ b/code/modules/asset_cache/assets/rcd.dm
@@ -27,24 +27,26 @@
 			Insert(sprite_name = sanitize_css_class_name(icon_state), I = icon)
 
 	//for each airlock type we create its overlayed version with the suffix Glass in the sprite name
+	//EFFIGY EDIT START - Updated airlock sprites for RCD
 	var/list/airlocks = list(
-		"Standard" = 'icons/obj/doors/airlocks/station/public.dmi',
-		"Public" = 'icons/obj/doors/airlocks/station2/glass.dmi',
-		"Engineering" = 'icons/obj/doors/airlocks/station/engineering.dmi',
-		"Atmospherics" = 'icons/obj/doors/airlocks/station/atmos.dmi',
-		"Security" = 'icons/obj/doors/airlocks/station/security.dmi',
-		"Command" = 'icons/obj/doors/airlocks/station/command.dmi',
-		"Medical" = 'icons/obj/doors/airlocks/station/medical.dmi',
-		"Research" = 'icons/obj/doors/airlocks/station/research.dmi',
+		"Standard" = 'packages/gfx/assets/obj/airlock/station/generic.dmi',
+		"Public" = 'packages/gfx/assets/obj/airlock/station2/glass.dmi',
+		"Engineering" = 'packages/gfx/assets/obj/airlock/station/engi.dmi',
+		"Atmospherics" = 'packages/gfx/assets/obj/airlock/station/atmos.dmi',
+		"Security" = 'packages/gfx/assets/obj/airlock/station/sec.dmi',
+		"Command" = 'packages/gfx/assets/obj/airlock/station/com.dmi',
+		"Medical" = 'packages/gfx/assets/obj/airlock/station/med.dmi',
+		"Research" = 'packages/gfx/assets/obj/airlock/station/rnd.dmi',
 		"Freezer" = 'icons/obj/doors/airlocks/station/freezer.dmi',
-		"Virology" = 'icons/obj/doors/airlocks/station/virology.dmi',
-		"Mining" = 'icons/obj/doors/airlocks/station/mining.dmi',
-		"Maintenance" = 'icons/obj/doors/airlocks/station/maintenance.dmi',
+		"Virology" = 'packages/gfx/assets/obj/airlock/station/viro.dmi',
+		"Mining" = 'packages/gfx/assets/obj/airlock/station/cargo.dmi',
+		"Maintenance" = 'packages/gfx/assets/obj/airlock/station/maint-int.dmi',
 		"External" = 'icons/obj/doors/airlocks/external/external.dmi',
-		"External Maintenance" = 'icons/obj/doors/airlocks/station/maintenanceexternal.dmi',
+		"External Maintenance" = 'packages/gfx/assets/obj/airlock/station/maint-ext.dmi',
 		"Airtight Hatch" = 'icons/obj/doors/airlocks/hatch/centcom.dmi',
 		"Maintenance Hatch" = 'icons/obj/doors/airlocks/hatch/maintenance.dmi'
 	)
+	//EFFIGY EDIT END
 	//these 3 types dont have glass doors
 	var/list/exclusion = list("Freezer", "Airtight Hatch", "Maintenance Hatch")
 

--- a/packages/gfx/airlock.dm
+++ b/packages/gfx/airlock.dm
@@ -244,6 +244,55 @@
 	glass_type = /obj/machinery/door/airlock/service/studio/glass
 	airlock_type = /obj/machinery/door/airlock/service/studio
 
+// EFFIGY DOOR ASSEMBLYS
+
+/obj/structure/door_assembly
+	icon = 'packages/gfx/assets/obj/airlock/station/generic.dmi'
+	overlays_file = 'packages/gfx/assets/obj/airlock/station/overlays.dmi'
+
+/obj/structure/door_assembly/door_assembly_public
+	icon = 'packages/gfx/assets/obj/airlock/station2/glass.dmi'
+	overlays_file = 'packages/gfx/assets/obj/airlock/station/overlays.dmi'
+
+/obj/structure/door_assembly/door_assembly_com
+	icon = 'packages/gfx/assets/obj/airlock/station/com.dmi'
+
+/obj/structure/door_assembly/door_assembly_sec
+	icon = 'packages/gfx/assets/obj/airlock/station/sec.dmi'
+
+/obj/structure/door_assembly/door_assembly_eng
+	icon = 'packages/gfx/assets/obj/airlock/station/engi.dmi'
+
+/obj/structure/door_assembly/door_assembly_min
+	icon = 'packages/gfx/assets/obj/airlock/station/cargo.dmi'
+
+/obj/structure/door_assembly/door_assembly_atmo
+	icon = 'packages/gfx/assets/obj/airlock/station/atmos.dmi'
+
+/obj/structure/door_assembly/door_assembly_research
+	icon = 'packages/gfx/assets/obj/airlock/station/rnd.dmi'
+
+/obj/structure/door_assembly/door_assembly_science
+	icon = 'packages/gfx/assets/obj/airlock/station/sci.dmi'
+
+/obj/structure/door_assembly/door_assembly_med
+	icon = 'packages/gfx/assets/obj/airlock/station/med.dmi'
+
+/obj/structure/door_assembly/door_assembly_hydro
+	icon = 'packages/gfx/assets/obj/airlock/station/hydro.dmi'
+
+/obj/structure/door_assembly/door_assembly_viro
+	icon = 'packages/gfx/assets/obj/airlock/station/viro.dmi'
+
+/obj/structure/door_assembly/door_assembly_silver
+	icon = 'packages/gfx/assets/obj/airlock/station/silver.dmi'
+
+/obj/structure/door_assembly/door_assembly_mai
+	icon = 'packages/gfx/assets/obj/airlock/station/maint-int.dmi'
+
+/obj/structure/door_assembly/door_assembly_extmai
+	icon = 'packages/gfx/assets/obj/airlock/station/maint-ext.dmi'
+
 #undef AIRLOCK_LIGHT_POWER
 #undef AIRLOCK_LIGHT_RANGE
 #undef AIRLOCK_LIGHT_ENGINEERING

--- a/packages/gfx/airlock.dm
+++ b/packages/gfx/airlock.dm
@@ -244,7 +244,7 @@
 	glass_type = /obj/machinery/door/airlock/service/studio/glass
 	airlock_type = /obj/machinery/door/airlock/service/studio
 
-// EFFIGY DOOR ASSEMBLYS
+// EFFIGY DOOR ASSEMBLIES
 
 /obj/structure/door_assembly
 	icon = 'packages/gfx/assets/obj/airlock/station/generic.dmi'


### PR DESCRIPTION
## About The Pull Request

Updates the airlock assembly to use the new sprites instead of the old. 
Additionally updates the RCD selector to show the new airlock sprites instead of the old ones as well.

Bad old 
![image](https://github.com/effigy-se/effigy-se/assets/84706993/ac72d2ac-19ab-4055-8bcd-ad69cea8d3c8)

New good
![image](https://github.com/effigy-se/effigy-se/assets/84706993/69024872-0fab-45da-b511-d4503e6fe102)

RCD:
![image](https://github.com/effigy-se/effigy-se/assets/84706993/9d16a1ea-9908-491b-b021-4c130c32b410)


resolves #197 

## Changelog
:cl:
fix: Updated door_assembly sprites
fix: Updated RCD selector airlock sprites
/:cl: