### PR TITLE
Fixes pixel shift on stand up

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -640,8 +640,8 @@
 	if(resting || body_position == STANDING_UP || HAS_TRAIT(src, TRAIT_FLOORED))
 		return
 	to_chat(src, span_notice("You stand up."))
-	set_lying_angle(0)
 	set_body_position(STANDING_UP)
+	set_lying_angle(0)
 	// EFFIGY EDIT CHANGE END
 
 


### PR DESCRIPTION

## About The Pull Request

As was noticed last round. If you stood up you retained the lay down pixel shift of -6 pixels.
After some debugging I realized it was just two procs firing off in the incorrect order.

## Why It's Good For The Game

Don't have to use pixel shifting to fix the broken pixel shift.

## Changelog


:cl:
fix: Fixed retaining lay down pixel shift upon standing.
/:cl:
