### PR TITLE
Adds toggle for climax sound and tagging system for playsound()

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -37,9 +37,8 @@
  * pressure_affected - Whether or not difference in pressure affects the sound (E.g. if you can hear in space).
  * ignore_walls - Whether or not the sound can pass through walls.
  * falloff_distance - Distance at which falloff begins. Sound is at peak volume (in regards to falloff) aslong as it is in this range.
- * tag - A string tag associated with the sound (e.x. "climax" tag for prefs)
  */
-/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff_exponent = SOUND_FALLOFF_EXPONENT, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, use_reverb = TRUE, tag = "")
+/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff_exponent = SOUND_FALLOFF_EXPONENT, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, use_reverb = TRUE)
 	if(isarea(source))
 		CRASH("playsound(): source is an area")
 
@@ -80,20 +79,12 @@
 
 	for(var/mob/listening_mob in listeners | SSmobs.dead_players_by_zlevel[source_z])//observers always hear through walls
 		if(get_dist(listening_mob, turf_source) <= maxdistance)
-			listening_mob.playsound_local(turf_source, soundin, vol, vary, frequency, falloff_exponent, channel, pressure_affected, S, maxdistance, falloff_distance, 1, use_reverb, tag)
+			listening_mob.playsound_local(turf_source, soundin, vol, vary, frequency, falloff_exponent, channel, pressure_affected, S, maxdistance, falloff_distance, 1, use_reverb)
 			. += listening_mob
 
-/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff_exponent = SOUND_FALLOFF_EXPONENT, channel = 0, pressure_affected = TRUE, sound/sound_to_use, max_distance, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, distance_multiplier = 1, use_reverb = TRUE , tag = "")
+/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff_exponent = SOUND_FALLOFF_EXPONENT, channel = 0, pressure_affected = TRUE, sound/sound_to_use, max_distance, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, distance_multiplier = 1, use_reverb = TRUE)
 	if(!client || !can_hear())
 		return
-
-	// Processes whatever tag is associated with the sound() proc call
-	switch(tag)
-
-		// Kills the sound if it's a climax and disabled in prefs
-		if("climax")
-			if(!client?.prefs?.read_preference(/datum/preference/toggle/erp/climax_sound))
-				return
 
 	if(!sound_to_use)
 		sound_to_use = sound(get_sfx(soundin))

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -37,8 +37,9 @@
  * pressure_affected - Whether or not difference in pressure affects the sound (E.g. if you can hear in space).
  * ignore_walls - Whether or not the sound can pass through walls.
  * falloff_distance - Distance at which falloff begins. Sound is at peak volume (in regards to falloff) aslong as it is in this range.
+ * tag - A string tag associated with the sound (e.x. "climax" tag for prefs)
  */
-/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff_exponent = SOUND_FALLOFF_EXPONENT, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, use_reverb = TRUE)
+/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff_exponent = SOUND_FALLOFF_EXPONENT, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, use_reverb = TRUE, tag = "")
 	if(isarea(source))
 		CRASH("playsound(): source is an area")
 
@@ -79,12 +80,20 @@
 
 	for(var/mob/listening_mob in listeners | SSmobs.dead_players_by_zlevel[source_z])//observers always hear through walls
 		if(get_dist(listening_mob, turf_source) <= maxdistance)
-			listening_mob.playsound_local(turf_source, soundin, vol, vary, frequency, falloff_exponent, channel, pressure_affected, S, maxdistance, falloff_distance, 1, use_reverb)
+			listening_mob.playsound_local(turf_source, soundin, vol, vary, frequency, falloff_exponent, channel, pressure_affected, S, maxdistance, falloff_distance, 1, use_reverb, tag)
 			. += listening_mob
 
-/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff_exponent = SOUND_FALLOFF_EXPONENT, channel = 0, pressure_affected = TRUE, sound/sound_to_use, max_distance, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, distance_multiplier = 1, use_reverb = TRUE)
+/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff_exponent = SOUND_FALLOFF_EXPONENT, channel = 0, pressure_affected = TRUE, sound/sound_to_use, max_distance, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, distance_multiplier = 1, use_reverb = TRUE , tag = "")
 	if(!client || !can_hear())
 		return
+
+	// Processes whatever tag is associated with the sound() proc call
+	switch(tag)
+
+		// Kills the sound if it's a climax and disabled in prefs
+		if("climax")
+			if(!client?.prefs?.read_preference(/datum/preference/toggle/erp/climax_sound))
+				return
 
 	if(!sound_to_use)
 		sound_to_use = sound(get_sfx(soundin))

--- a/local/code/modules/client/preferences/erp_preferences.dm
+++ b/local/code/modules/client/preferences/erp_preferences.dm
@@ -115,6 +115,10 @@
 /datum/preference/toggle/erp/new_genitalia_growth
 	savefile_key = "new_genitalia_growth_pref"
 
+/datum/preference/toggle/erp/climax_sound
+	savefile_key = "climax_sound_perf"
+	default_value = TRUE
+
 /datum/preference/choiced/erp_status
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
 	savefile_identifier = PREFERENCE_CHARACTER

--- a/packages/lewd/lewd_arousal/climax.dm
+++ b/packages/lewd/lewd_arousal/climax.dm
@@ -5,14 +5,7 @@
 #define CLIMAX_ON_FLOOR "On the floor"
 #define CLIMAX_IN_OR_ON "Climax in or on someone"
 
-#define CLIMAX_SOUND_MAX_DISTANCE 5
-
-// Plays the climax sound in a 5 tile radius IF someone has it enabled in their prefs
-/mob/living/carbon/human/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff_exponent = SOUND_FALLOFF_EXPONENT, channel = 0, pressure_affected = TRUE, sound/sound_to_use, max_distance, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, distance_multiplier = 1, use_reverb = TRUE, sound_preference)
-	var/datum/preference/toggle/client_sound_preference = client?.prefs?.read_preference(sound_preference)
-	if(!isnull(sound_preference) && !sound_preference)
-		return
-	. = ..()
+#define CLIMAX_NO_ESCAPE_ZONE 5
 
 /mob/living/carbon/human/proc/climax(manual = TRUE)
 	if (CONFIG_GET(flag/disable_erp_preferences))
@@ -43,16 +36,26 @@
 			genitals.Add(CLIMAX_PENIS)
 		climax_choice = tgui_alert(src, "You are climaxing, choose which genitalia to climax with.", "Genitalia Preference!", genitals)
 
+	var/sound/cumsound
 	switch(gender)
 		if(MALE)
-			playsound_local(get_turf(src), pick('packages/lewd/assets/sounds/final_m1.ogg',
-										'packages/lewd/assets/sounds/final_m2.ogg',
-										'packages/lewd/assets/sounds/final_m3.ogg'), vol = 50, max_distance = CLIMAX_SOUND_MAX_DISTANCE, sound_preference = /datum/preference/toggle/erp/climax_sound)
+			cumsound = sound(pick(
+				'packages/lewd/assets/sounds/final_m1.ogg',
+				'packages/lewd/assets/sounds/final_m2.ogg',
+				'packages/lewd/assets/sounds/final_m3.ogg',
+			))
 
 		else
-			playsound_local(get_turf(src), pick('packages/lewd/assets/sounds/final_f1.ogg',
-									'packages/lewd/assets/sounds/final_f2.ogg',
-									'packages/lewd/assets/sounds/final_f3.ogg'), 50, max_distance = CLIMAX_SOUND_MAX_DISTANCE, sound_preference = /datum/preference/toggle/erp/climax_sound)
+			cumsound = (pick(
+				'packages/lewd/assets/sounds/final_f1.ogg',
+				'packages/lewd/assets/sounds/final_f2.ogg',
+				'packages/lewd/assets/sounds/final_f3.ogg',
+			))
+
+	var/list/cumheads = get_hearers_in_view(CLIMAX_NO_ESCAPE_ZONE, get_turf(src))
+	for(var/mob/horrified in cumheads)
+		if(horrified.client.prefs.read_preference(/datum/preference/toggle/erp/climax_sound))
+			SEND_SOUND(horrified.client, cumsound)
 
 	var/self_orgasm = FALSE
 	var/self_their = p_their()

--- a/packages/lewd/lewd_arousal/climax.dm
+++ b/packages/lewd/lewd_arousal/climax.dm
@@ -5,17 +5,14 @@
 #define CLIMAX_ON_FLOOR "On the floor"
 #define CLIMAX_IN_OR_ON "Climax in or on someone"
 
+#define CLIMAX_SOUND_MAX_DISTANCE 5
+
 // Plays the climax sound in a 5 tile radius IF someone has it enabled in their prefs
-/proc/playsound_climax(atom/source, soundin, vol as num)
-
-	var/maxdistance = 5
-	var/turf/turf_source = get_turf(source)
-	var/list/listeners = get_hearers_in_view(5, turf_source)
-
-	for(var/mob/listening_mob in listeners)
-
-		if(get_dist(listening_mob, turf_source) <= maxdistance && listening_mob?.client?.prefs?.read_preference(/datum/preference/toggle/erp/climax_sound))
-			listening_mob.playsound_local(turf_source, soundin, vol)
+/mob/living/carbon/human/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff_exponent = SOUND_FALLOFF_EXPONENT, channel = 0, pressure_affected = TRUE, sound/sound_to_use, max_distance, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, distance_multiplier = 1, use_reverb = TRUE, sound_preference)
+	var/datum/preference/toggle/client_sound_preference = client?.prefs?.read_preference(sound_preference)
+	if(!isnull(sound_preference) && !sound_preference)
+		return
+	. = ..()
 
 /mob/living/carbon/human/proc/climax(manual = TRUE)
 	if (CONFIG_GET(flag/disable_erp_preferences))
@@ -48,13 +45,14 @@
 
 	switch(gender)
 		if(MALE)
-			playsound_climax(get_turf(src), pick('packages/lewd/assets/sounds/final_m1.ogg',
+			playsound_local(get_turf(src), pick('packages/lewd/assets/sounds/final_m1.ogg',
 										'packages/lewd/assets/sounds/final_m2.ogg',
-										'packages/lewd/assets/sounds/final_m3.ogg'), 50)
-		if(FEMALE)
-			playsound_climax(get_turf(src), pick('packages/lewd/assets/sounds/final_f1.ogg',
-										'packages/lewd/assets/sounds/final_f2.ogg',
-										'packages/lewd/assets/sounds/final_f3.ogg'), 50)
+										'packages/lewd/assets/sounds/final_m3.ogg'), vol = 50, max_distance = CLIMAX_SOUND_MAX_DISTANCE, sound_preference = /datum/preference/toggle/erp/climax_sound)
+
+		else
+			playsound_local(get_turf(src), pick('packages/lewd/assets/sounds/final_f1.ogg',
+									'packages/lewd/assets/sounds/final_f2.ogg',
+									'packages/lewd/assets/sounds/final_f3.ogg'), 50, max_distance = CLIMAX_SOUND_MAX_DISTANCE, sound_preference = /datum/preference/toggle/erp/climax_sound)
 
 	var/self_orgasm = FALSE
 	var/self_their = p_their()

--- a/packages/lewd/lewd_arousal/climax.dm
+++ b/packages/lewd/lewd_arousal/climax.dm
@@ -5,6 +5,18 @@
 #define CLIMAX_ON_FLOOR "On the floor"
 #define CLIMAX_IN_OR_ON "Climax in or on someone"
 
+// Plays the climax sound in a 5 tile radius IF someone has it enabled in their prefs
+/proc/playsound_climax(atom/source, soundin, vol as num)
+
+	var/maxdistance = 5
+	var/turf/turf_source = get_turf(source)
+	var/list/listeners = get_hearers_in_view(5, turf_source)
+
+	for(var/mob/listening_mob in listeners)
+
+		if(get_dist(listening_mob, turf_source) <= maxdistance && listening_mob?.client?.prefs?.read_preference(/datum/preference/toggle/erp/climax_sound))
+			listening_mob.playsound_local(turf_source, soundin, vol)
+
 /mob/living/carbon/human/proc/climax(manual = TRUE)
 	if (CONFIG_GET(flag/disable_erp_preferences))
 		return
@@ -36,13 +48,13 @@
 
 	switch(gender)
 		if(MALE)
-			playsound(get_turf(src), pick('packages/lewd/assets/sounds/final_m1.ogg',
+			playsound_climax(get_turf(src), pick('packages/lewd/assets/sounds/final_m1.ogg',
 										'packages/lewd/assets/sounds/final_m2.ogg',
-										'packages/lewd/assets/sounds/final_m3.ogg'), 50, TRUE, ignore_walls = FALSE, tag = "climax")
+										'packages/lewd/assets/sounds/final_m3.ogg'), 50)
 		if(FEMALE)
-			playsound(get_turf(src), pick('packages/lewd/assets/sounds/final_f1.ogg',
+			playsound_climax(get_turf(src), pick('packages/lewd/assets/sounds/final_f1.ogg',
 										'packages/lewd/assets/sounds/final_f2.ogg',
-										'packages/lewd/assets/sounds/final_f3.ogg'), 50, TRUE, ignore_walls = FALSE, tag = "climax")
+										'packages/lewd/assets/sounds/final_f3.ogg'), 50)
 
 	var/self_orgasm = FALSE
 	var/self_their = p_their()

--- a/packages/lewd/lewd_arousal/climax.dm
+++ b/packages/lewd/lewd_arousal/climax.dm
@@ -38,11 +38,11 @@
 		if(MALE)
 			playsound(get_turf(src), pick('packages/lewd/assets/sounds/final_m1.ogg',
 										'packages/lewd/assets/sounds/final_m2.ogg',
-										'packages/lewd/assets/sounds/final_m3.ogg'), 50, TRUE, ignore_walls = FALSE)
+										'packages/lewd/assets/sounds/final_m3.ogg'), 50, TRUE, ignore_walls = FALSE, tag = "climax")
 		if(FEMALE)
 			playsound(get_turf(src), pick('packages/lewd/assets/sounds/final_f1.ogg',
 										'packages/lewd/assets/sounds/final_f2.ogg',
-										'packages/lewd/assets/sounds/final_f3.ogg'), 50, TRUE, ignore_walls = FALSE)
+										'packages/lewd/assets/sounds/final_f3.ogg'), 50, TRUE, ignore_walls = FALSE, tag = "climax")
 
 	var/self_orgasm = FALSE
 	var/self_their = p_their()

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/skyrat/erp_preferences.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/skyrat/erp_preferences.tsx
@@ -123,3 +123,11 @@ export const new_genitalia_growth_pref: FeatureToggle = {
     'If checked, allows drugs to grow new genitalia on your character.',
   component: CheckboxInput,
 };
+
+export const climax_sound_perf: FeatureToggle = {
+  name: 'Toggle climax sound',
+  category: 'ERP',
+  description:
+    'Toggles climax sound.',
+  component: CheckboxInput,
+};

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/skyrat/erp_preferences.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/skyrat/erp_preferences.tsx
@@ -127,7 +127,6 @@ export const new_genitalia_growth_pref: FeatureToggle = {
 export const climax_sound_perf: FeatureToggle = {
   name: 'Toggle climax sound',
   category: 'ERP',
-  description:
-    'Toggles climax sound.',
+  description: 'Toggles the climax sound.',
   component: CheckboxInput,
 };


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a toggle to let people locally disable the climax sound effect. Also adds a tagging system to the playsound() proc in sound.dm which lets you tag a proc call. Future PRs could include other tags such as toy noises.

## Why It's Good For The Game

The doomguy climax sound currently has no toggle and is unpleasant.

Adds more user controls to their prefs

## Changelog

:cl:
add: Toggle option for climax noise
add: tagging system for playsound() proc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
