### PR TITLE
[MDB Ignore] Fixes Decals

### DIFF
--- a/_maps/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/map_files/FoxHoleStation/foxholestation.dmm
@@ -2358,7 +2358,7 @@
 /area/station/medical/cryo)
 "btL" = (
 /obj/effect/turf_decal/box/white/corners{
-	dir = 8
+	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 1
@@ -10721,7 +10721,7 @@
 /area/station/science)
 "gne" = (
 /obj/effect/turf_decal/box/corners{
-	dir = 8
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -13876,9 +13876,6 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "ibt" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -13887,6 +13884,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "ibM" = (
@@ -17488,7 +17488,7 @@
 /area/station/hallway/secondary/command)
 "kho" = (
 /obj/effect/turf_decal/box/white/corners{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -40296,7 +40296,7 @@
 /area/station/service/kitchen/coldroom)
 "xgW" = (
 /obj/effect/turf_decal/box/white/corners{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 1
@@ -41478,7 +41478,7 @@
 /area/station/maintenance/aft/greater)
 "xMD" = (
 /obj/effect/turf_decal/box/corners{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -41487,7 +41487,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)

--- a/_maps/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/map_files/FoxHoleStation/foxholestation.dmm
@@ -1259,7 +1259,7 @@
 /area/station/engineering/engine_smes)
 "aMO" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/railing/corner{
 	dir = 8
@@ -2758,7 +2758,7 @@
 /area/station/maintenance/aft/greater)
 "bFq" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 10
@@ -3357,7 +3357,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 1
 	},
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/effect/spawner/random/engineering/toolbox,
@@ -5179,7 +5179,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -5734,7 +5734,7 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/pod,
 /area/station/maintenance/disposal)
@@ -6634,7 +6634,7 @@
 /area/station/cargo/storage)
 "dQM" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
@@ -6653,7 +6653,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
@@ -6869,7 +6869,7 @@
 "dXZ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
@@ -10835,7 +10835,7 @@
 "gpG" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -14768,7 +14768,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/turf_decal/caution/red,
 /turf/open/floor/plating,
@@ -16030,7 +16030,7 @@
 /area/station/commons/dorms/room3)
 "jmZ" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 1
 	},
 /obj/structure/railing/corner{
 	dir = 1
@@ -16073,7 +16073,7 @@
 "jol" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
@@ -18113,7 +18113,7 @@
 /area/station/engineering/atmos)
 "kzZ" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 4
 	},
 /obj/structure/railing/corner{
 	dir = 4
@@ -18804,7 +18804,7 @@
 "kXq" = (
 /obj/effect/decal/cleanable/oil/streak,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 1
 	},
 /obj/structure/railing/corner{
 	dir = 1
@@ -20514,7 +20514,7 @@
 "lZz" = (
 /obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -20725,7 +20725,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/pod/dark,
 /area/station/maintenance/port/central)
@@ -21968,7 +21968,7 @@
 /area/station/hallway/secondary/entry)
 "mSz" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -22506,7 +22506,7 @@
 /area/station/medical/medbay/central)
 "nmj" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/white/corner{
 	dir = 1
@@ -23902,7 +23902,7 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/pod/dark,
 /area/station/maintenance/port/central)
@@ -24908,7 +24908,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -26623,7 +26623,7 @@
 "pJt" = (
 /obj/structure/floodlight_frame,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
@@ -27372,7 +27372,7 @@
 "qfA" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/hallway/primary/port)
@@ -28326,7 +28326,7 @@
 /area/station/commons/fitness/recreation/entertainment)
 "qJw" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -28776,7 +28776,7 @@
 /area/station/ai_monitored/command/storage/eva)
 "qTs" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/iron/half,
 /area/station/security/prison/upper)
@@ -30372,7 +30372,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/white/corner{
 	dir = 8
@@ -30613,7 +30613,7 @@
 /area/station/tcommsat/computer)
 "rXX" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/white/corner{
 	dir = 1
@@ -30776,7 +30776,7 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31311,7 +31311,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -35307,7 +35307,7 @@
 "uzZ" = (
 /obj/effect/turf_decal/trimline/green/filled/warning,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/shrink_cw{
 	dir = 4
@@ -39098,7 +39098,7 @@
 "wAv" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
@@ -39832,7 +39832,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/white/corner{
 	dir = 4
@@ -40531,7 +40531,7 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "xlN" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 1
 	},
 /obj/structure/cable,
 /obj/effect/landmark/start/depsec/science,
@@ -117020,9 +117020,9 @@ bwl
 jTa
 jTa
 uOH
-iAc
-jUb
 jol
+jUb
+iAc
 bJC
 jTa
 jTa

--- a/_maps/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/map_files/FoxHoleStation/foxholestation.dmm
@@ -1072,7 +1072,7 @@
 "aHX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/red/corner{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6096,7 +6096,7 @@
 /area/station/maintenance/fore)
 "dwZ" = (
 /obj/effect/turf_decal/stripes/red/corner{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/turf_decal/arrows/red{
 	dir = 8
@@ -7082,7 +7082,7 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/glasses/meson/engine/tray,
 /obj/effect/turf_decal/stripes/red/corner{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 10
@@ -15275,7 +15275,7 @@
 /area/station/science/xenobiology)
 "iPC" = (
 /obj/effect/turf_decal/stripes/red/corner{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -22374,7 +22374,7 @@
 "ngN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/red/corner{
-	dir = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -22509,7 +22509,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/white/corner{
-	dir = 1
+	dir = 4
 	},
 /obj/machinery/light/directional/north,
 /obj/structure/cable,
@@ -28650,7 +28650,7 @@
 /area/station/security/prison/upper)
 "qPV" = (
 /obj/effect/turf_decal/stripes/red/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/arrows/red{
 	dir = 4
@@ -30374,15 +30374,15 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/white/corner{
-	dir = 8
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/white/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "rQu" = (
@@ -30616,7 +30616,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/white/corner{
-	dir = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/white/textured_large,
@@ -33944,7 +33944,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/red/corner{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -39834,12 +39834,12 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/white/corner{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/white/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "wVf" = (
@@ -66650,11 +66650,11 @@ rOj
 hSG
 vHi
 iHO
-qPV
+gQN
 rqD
 gCX
 rqD
-gQN
+qPV
 azW
 gLZ
 wcW

--- a/_maps/map_files/MiniStation/MiniStation.dmm
+++ b/_maps/map_files/MiniStation/MiniStation.dmm
@@ -3291,10 +3291,10 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -4517,10 +4517,10 @@
 	name = "Robotics Desk";
 	req_access = list("robotics")
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/science/research)
 "kP" = (
@@ -5718,11 +5718,11 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "nP" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "nQ" = (
@@ -6465,7 +6465,7 @@
 /area/station/hallway/primary/aft)
 "pI" = (
 /obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/freezer,
 /area/station/service/cafeteria)
 "pJ" = (
 /mob/living/basic/mouse/brown/tom,
@@ -6852,13 +6852,13 @@
 "qN" = (
 /obj/machinery/ticket_machine/directional/south,
 /obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
 /obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/side{
@@ -8201,10 +8201,10 @@
 /area/station/engineering/supermatter)
 "uE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /obj/structure/cable/layer1,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "uF" = (
@@ -8219,7 +8219,7 @@
 /area/station/engineering/main)
 "uH" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/station/engineering/main)
@@ -9392,14 +9392,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "xO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
 /obj/machinery/smartfridge/petri/preloaded,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "xP" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
@@ -10861,9 +10858,6 @@
 /area/station/science/research)
 "Bm" = (
 /obj/structure/table,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/item/storage/box/bodybags{
 	pixel_x = 9;
 	pixel_y = 9
@@ -10919,6 +10913,9 @@
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#d1dfff"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/research)
@@ -11213,10 +11210,10 @@
 /area/station/science/research)
 "BW" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/machinery/computer/mech_bay_power_console,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "BX" = (
@@ -13917,7 +13914,7 @@
 "Ke" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit)
@@ -15818,11 +15815,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "Rp" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/light,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "Rr" = (
@@ -16401,7 +16398,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
@@ -16696,7 +16693,7 @@
 /area/station/security/brig)
 "UN" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit)
@@ -17223,7 +17220,7 @@
 /area/station/service/cafeteria)
 "WH" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
@@ -43938,9 +43935,9 @@ xf
 Th
 JO
 JO
-Tx
-iw
 WH
+iw
+Tx
 JO
 JO
 GN
@@ -44463,7 +44460,7 @@ ay
 jS
 ay
 XW
-WH
+Tx
 UX
 lP
 hN


### PR DESCRIPTION
Updatepaths fucked these up on Foxhole and Mini. Ugh.

This fixes. All of that.
## Changelog
:cl:
fix: Stripes are no longer pointing the wrong way on foxhole.
/:cl:
