### PR TITLE
[Bounty] Adds The Option For Missing A Limb To The Prosthetics Menu

### DIFF
--- a/packages/customization/modules/client/augment/limbs.dm
+++ b/packages/customization/modules/client/augment/limbs.dm
@@ -67,6 +67,12 @@
 	path = /obj/item/bodypart/arm/left/plasmaman
 	uses_robotic_styles = FALSE
 
+/datum/augment_item/limb/l_arm/selfdestruct
+	name = "No Left Arm"
+	path = /obj/item/bodypart/arm/left/selfdestruct
+	cost = -2
+	uses_robotic_styles = FALSE
+
 //RIGHT ARMS
 /datum/augment_item/limb/r_arm
 	slot = AUGMENT_SLOT_R_ARM
@@ -83,6 +89,12 @@
 /datum/augment_item/limb/r_arm/plasmaman
 	name = "Plasmaman right arm"
 	path = /obj/item/bodypart/arm/right/plasmaman
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/selfdestruct
+	name = "No Right Arm"
+	path = /obj/item/bodypart/arm/right/selfdestruct
+	cost = -2
 	uses_robotic_styles = FALSE
 
 //LEFT LEGS
@@ -103,6 +115,12 @@
 	path = /obj/item/bodypart/leg/left/plasmaman
 	uses_robotic_styles = FALSE
 
+/datum/augment_item/limb/l_leg/selfdestruct
+	name = "No Left Leg"
+	path = /obj/item/bodypart/leg/left/selfdestruct
+	cost = -2
+	uses_robotic_styles = FALSE
+
 //RIGHT LEGS
 /datum/augment_item/limb/r_leg
 	slot = AUGMENT_SLOT_R_LEG
@@ -119,4 +137,10 @@
 /datum/augment_item/limb/r_leg/plasmaman
 	name = "Plasmaman right leg"
 	path = /obj/item/bodypart/leg/right/plasmaman
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/selfdestruct
+	name = "No Right Leg"
+	path = /obj/item/bodypart/leg/right/selfdestruct
+	cost = -2
 	uses_robotic_styles = FALSE

--- a/packages/customization/modules/surgery/bodyparts/parts.dm
+++ b/packages/customization/modules/surgery/bodyparts/parts.dm
@@ -1,0 +1,20 @@
+/// Self Destructing Bodyparts, For Augmentation. I'm leaving out heads + chests as, while it would be cool for synths, I also don't want people to start the round unrevivable sans botany because they're dumb as heck. You know who and what you are.
+/obj/item/bodypart/arm/left/selfdestruct/try_attach_limb(mob/living/carbon/limb_owner, special)
+	. = ..()
+	drop_limb()
+	qdel(src)
+
+/obj/item/bodypart/arm/right/selfdestruct/try_attach_limb(mob/living/carbon/limb_owner, special)
+	. = ..()
+	drop_limb()
+	qdel(src)
+
+/obj/item/bodypart/leg/left/selfdestruct/try_attach_limb(mob/living/carbon/limb_owner, special)
+	. = ..()
+	drop_limb()
+	qdel(src)
+
+/obj/item/bodypart/leg/right/selfdestruct/try_attach_limb(mob/living/carbon/limb_owner, special)
+	. = ..()
+	drop_limb()
+	qdel(src)

--- a/packages/customization/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/packages/customization/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -21,3 +21,25 @@
 /obj/item/bodypart/chest/robot/weak
 	brute_reduction = 0
 	burn_reduction = 0
+
+/// Self Destructing Bodyparts, For Augmentation. I'm leaving out heads + chests as, while it would be cool for synths, I also don't want people to start the round unrevivable sans botany because they're
+/// dumb as heck. You know who and what you are.
+/obj/item/bodypart/arm/left/selfdestruct/try_attach_limb(mob/living/carbon/limb_owner, special)
+	. = ..()
+	drop_limb()
+	qdel(src)
+
+/obj/item/bodypart/arm/right/selfdestruct/try_attach_limb(mob/living/carbon/limb_owner, special)
+	. = ..()
+	drop_limb()
+	qdel(src)
+
+/obj/item/bodypart/leg/left/selfdestruct/try_attach_limb(mob/living/carbon/limb_owner, special)
+	. = ..()
+	drop_limb()
+	qdel(src)
+
+/obj/item/bodypart/leg/right/selfdestruct/try_attach_limb(mob/living/carbon/limb_owner, special)
+	. = ..()
+	drop_limb()
+	qdel(src)

--- a/packages/customization/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/packages/customization/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -21,25 +21,3 @@
 /obj/item/bodypart/chest/robot/weak
 	brute_reduction = 0
 	burn_reduction = 0
-
-/// Self Destructing Bodyparts, For Augmentation. I'm leaving out heads + chests as, while it would be cool for synths, I also don't want people to start the round unrevivable sans botany because they're
-/// dumb as heck. You know who and what you are.
-/obj/item/bodypart/arm/left/selfdestruct/try_attach_limb(mob/living/carbon/limb_owner, special)
-	. = ..()
-	drop_limb()
-	qdel(src)
-
-/obj/item/bodypart/arm/right/selfdestruct/try_attach_limb(mob/living/carbon/limb_owner, special)
-	. = ..()
-	drop_limb()
-	qdel(src)
-
-/obj/item/bodypart/leg/left/selfdestruct/try_attach_limb(mob/living/carbon/limb_owner, special)
-	. = ..()
-	drop_limb()
-	qdel(src)
-
-/obj/item/bodypart/leg/right/selfdestruct/try_attach_limb(mob/living/carbon/limb_owner, special)
-	. = ..()
-	drop_limb()
-	qdel(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5817,6 +5817,7 @@
 #include "packages\customization\modules\reagents\chemistry\recipes\medicine.dm"
 #include "packages\customization\modules\research\designs\misc_designs.dm"
 #include "packages\customization\modules\surgery\bodyparts\_bodyparts.dm"
+#include "packages\customization\modules\surgery\bodyparts\parts.dm"
 #include "packages\customization\modules\surgery\bodyparts\robot_bodyparts.dm"
 #include "packages\customization\modules\surgery\organs\cap.dm"
 #include "packages\customization\modules\surgery\organs\ears.dm"


### PR DESCRIPTION
## About The Pull Request
Adds the ability to forsake a limb for two quirk points. @lessthnthree , inadvertently creates more work for #264 (sorry!)
![image](https://github.com/effigy-se/effigy-se/assets/50649185/7f550437-f210-426a-82f0-4792ec4c3bb2)

*The way this works behind the scene is by making a new limb subtype that quickly detaches itself and qdels itself upon being applied. I wasn't in the mood to entirely refactor augments to account for forsaking limbs, but that would be preferable in the long run.*
## Why It's Good For The Game
Same reason plasmaman limbs were - more open character design. Even if I imagine some goofiness will unfold thanks to someone not thinking their choices through.
## Changelog
:cl:
add: You can now choose to forsake a limb in exchange for two quirk points, in the augments menu.
/:cl:
