### PR TITLE
Mining borgs can CRUSH all of lavaland again

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -717,7 +717,7 @@
 		/obj/item/extinguisher/mini,
 		/obj/item/storage/bag/sheetsnatcher/borg,
 		/obj/item/gun/energy/recharge/kinetic_accelerator/cyborg,
-		/obj/item/kinetic_crusher,
+		/obj/item/kinetic_crusher, //EffigyEdit Add - Borgs
 		/obj/item/gps/cyborg,
 		/obj/item/stack/marker_beacon,
 	)

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -717,6 +717,7 @@
 		/obj/item/extinguisher/mini,
 		/obj/item/storage/bag/sheetsnatcher/borg,
 		/obj/item/gun/energy/recharge/kinetic_accelerator/cyborg,
+		/obj/item/kinetic_crusher,
 		/obj/item/gps/cyborg,
 		/obj/item/stack/marker_beacon,
 	)


### PR DESCRIPTION
## About The Pull Request
Gives mining borgs a kinetic crusher!

## Why It's Good For The Game
They used to have these, but then it got removed, and honestly that's a tragedy.  Crushers let them have a slightly easier time fighting fauna, and lets them butcher corpses for more ore.  No more dragging dead creatures up to someone like some sort of cat!

https://github.com/effigy-se/effigy-se/assets/46330016/9ee4d846-5648-4b27-90c9-6767735b1878

## Changelog

:cl:
add: Adds a kinetic crusher to mining cyborgs.
/:cl:

