### PR TITLE
Excitable now applies on headpat instead of tailpull

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -510,6 +510,12 @@
 
 		if(HAS_TRAIT(src, TRAIT_BADTOUCH))
 			to_chat(helper, span_warning("[src] looks visibly upset as you pat [p_them()] on the head."))
+		// EFFIGY EDIT ADD START (Emotes)
+		if(HAS_TRAIT(src, TRAIT_EXCITABLE))
+			var/obj/item/organ/external/tail/src_tail = get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
+			if(src_tail && !(src_tail.wag_flags & WAG_WAGGING))
+				emote("wag")
+		// EFFIGY EDIT ADD END (Emotes)
 
 	else if ((helper.zone_selected == BODY_ZONE_PRECISE_GROIN) && !isnull(src.get_organ_by_type(/obj/item/organ/external/tail)))
 		helper.visible_message(span_notice("[helper] pulls on [src]'s tail!"), \
@@ -520,12 +526,6 @@
 			to_chat(helper, span_warning("[src] makes a grumbling noise as you pull on [p_their()] tail."))
 		else
 			add_mood_event("tailpulled", /datum/mood_event/tailpulled)
-		// EFFIGY EDIT ADD START (Emotes)
-		if(HAS_TRAIT(src, TRAIT_EXCITABLE))
-			var/obj/item/organ/external/tail/src_tail = get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
-			if(src_tail && !(src_tail.wag_flags & WAG_WAGGING))
-				emote("wag")
-		// EFFIGY EDIT ADD END (Emotes)
 
 	else if ((helper.zone_selected == BODY_ZONE_PRECISE_GROIN) && (istype(head, /obj/item/clothing/head/costume/kitty) || istype(head, /obj/item/clothing/head/collectable/kitty)))
 		var/obj/item/clothing/head/faketail = head


### PR DESCRIPTION
The order of operations on this one were wrong. Oops.

:cl:
fix: Excitable now applies on headpat instead of tailpull, as was intended. I would've had it apply on both but I am absolutely not making a new proc just for that when we're still in customization DEFCON 1. You wouldn't either!
/:cl:
