### PR TITLE
Foxhole - Oops, Removes the Redundant Station Relay

### DIFF
--- a/_maps/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/map_files/FoxHoleStation/foxholestation.dmm
@@ -400,6 +400,18 @@
 /obj/effect/landmark/start/geneticist,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
+"anh" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "anz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -761,13 +773,12 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig/upper)
 "axS" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/effect/turf_decal/siding/dark{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/engineering/tank,
-/turf/open/floor/pod/dark,
-/area/station/maintenance/aft/greater)
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "axU" = (
 /obj/effect/turf_decal/box/white{
 	color = "#EFB341"
@@ -962,6 +973,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
 /turf/open/floor/engine/hull,
@@ -1206,6 +1220,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/preset/ordnance{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
@@ -1610,10 +1627,14 @@
 /turf/open/floor/wood/large,
 /area/station/service/chapel)
 "aWV" = (
-/obj/effect/spawner/random/structure/grille,
-/obj/structure/window/spawner/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/greater)
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "aXh" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -2579,6 +2600,13 @@
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
+"byC" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "byD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3224,6 +3252,9 @@
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
 "bQo" = (
@@ -3263,10 +3294,12 @@
 	},
 /area/station/science/lower)
 "bRy" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "bRA" = (
@@ -3306,8 +3339,8 @@
 /turf/open/floor/iron,
 /area/station/commons)
 "bSw" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 6
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 1
 	},
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
@@ -3529,11 +3562,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "bZg" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 4
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
 	},
-/turf/open/floor/circuit/telecomms,
-/area/station/tcommsat/server/upper)
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "bZq" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5400,7 +5436,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/service/cafeteria)
 "daG" = (
-/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
 "daH" = (
@@ -5526,8 +5564,17 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/station/service/janitor)
 "ddn" = (
-/turf/closed/wall/r_wall,
-/area/station/tcommsat/server/upper)
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "ddp" = (
 /obj/machinery/requests_console/auto_name/directional/east,
 /obj/effect/mapping_helpers/requests_console/assistance,
@@ -5695,6 +5742,21 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"dit" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "diC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7656,12 +7718,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "epF" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
 "epI" = (
@@ -8066,11 +8123,13 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "eBm" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/apc/cell_10k,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/pod/dark,
-/area/station/tcommsat/server/upper)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/airless,
+/area/station/science/ordnance/bomb)
 "eBy" = (
 /obj/structure/industrial_lift/public,
 /obj/machinery/elevator_control_panel/directional/west{
@@ -8392,6 +8451,9 @@
 "eMz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "eMK" = (
@@ -8471,10 +8533,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "eQs" = (
-/obj/machinery/light/small/directional/south,
-/obj/machinery/telecomms/relay/preset/station,
-/turf/open/floor/circuit/telecomms,
-/area/station/tcommsat/server/upper)
+/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "eQx" = (
 /obj/machinery/door/airlock/research,
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
@@ -8586,6 +8650,9 @@
 	},
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
 	},
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
@@ -9409,9 +9476,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "fqW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/turf/open/floor/circuit/telecomms,
-/area/station/tcommsat/server/upper)
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "fqX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -9666,6 +9739,9 @@
 /area/station/commons/toilet/restrooms)
 "fwi" = (
 /obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
 /turf/open/floor/engine/hull,
@@ -10072,10 +10148,12 @@
 /turf/open/floor/iron/dark,
 /area/station/service/studio)
 "fIQ" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "fJc" = (
@@ -10288,6 +10366,7 @@
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
 "fSh" = (
@@ -10561,6 +10640,15 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating,
 /area/centcom/asteroid/nearstation)
+"gaN" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "gbt" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
@@ -10743,6 +10831,13 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white/small,
 /area/station/science/xenobiology)
+"ggy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/warning/docking/directional/west,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/aft/greater)
 "ggC" = (
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /obj/structure/cable,
@@ -10965,11 +11060,17 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "gnm" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/engineering/atmospherics_portable,
-/turf/open/floor/pod/dark,
-/area/station/maintenance/aft/greater)
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "gnn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11741,6 +11842,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /obj/effect/landmark/navigate_destination/minisat_access_ai,
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/textured_large,
 /area/station/maintenance/port/central)
 "gKp" = (
@@ -14969,6 +15071,11 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
+"iAd" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/space/openspace,
+/area/space/nearstation)
 "iAp" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 10
@@ -16663,15 +16770,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "jxX" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 4
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/dark,
-/area/station/maintenance/aft/greater)
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "jyb" = (
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 4
@@ -18580,6 +18684,9 @@
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
 "kEl" = (
@@ -18725,7 +18832,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/table,
 /obj/item/bdsm_candle{
 	pixel_y = 10;
@@ -21955,14 +22061,11 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "mDb" = (
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 8
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
 	},
-/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
-/obj/effect/mapping_helpers/airalarm/engine_access,
-/turf/open/floor/circuit/telecomms,
-/area/station/tcommsat/server/upper)
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "mDt" = (
 /turf/closed/wall/rock/porous,
 /area/centcom/asteroid/nearstation)
@@ -22468,6 +22571,7 @@
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/aft/greater)
 "mVC" = (
@@ -22673,9 +22777,9 @@
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
 "ncc" = (
-/obj/effect/landmark/atmospheric_sanity/ignore_area,
-/turf/closed/wall/r_wall,
-/area/station/tcommsat/server/upper)
+/obj/effect/turf_decal/siding/dark/end,
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "ncp" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
@@ -23743,6 +23847,21 @@
 	dir = 4
 	},
 /area/station/medical/medbay/central)
+"nRN" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "nRZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/mop_bucket/janitorialcart,
@@ -23830,9 +23949,13 @@
 /turf/closed/wall,
 /area/station/medical/medbay)
 "nUA" = (
-/obj/effect/turf_decal/trimline/yellow,
-/turf/open/floor/engine/hull,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/airless,
+/area/station/science/ordnance/bomb)
 "nUX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23862,6 +23985,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
@@ -24151,13 +24277,11 @@
 /turf/open/floor/wood,
 /area/station/security/brig/upper)
 "odk" = (
-/obj/effect/turf_decal/trimline/yellow/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/pod/dark,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "ods" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -24429,11 +24553,11 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen)
 "omv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/dark,
+/turf/open/floor/catwalk_floor,
 /area/station/maintenance/aft/greater)
 "omB" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
@@ -26994,7 +27118,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/chair_maintenance,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/aft/greater)
@@ -27125,6 +27248,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/starboard/central)
+"pJu" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/station/maintenance/aft/greater)
 "pJB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27441,16 +27574,17 @@
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/main)
 "pVa" = (
-/obj/machinery/door/airlock/engineering,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/pod/dark,
-/area/station/tcommsat/server/upper)
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "pVc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27977,13 +28111,8 @@
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison/mess)
 "qic" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/pod/dark,
-/area/station/tcommsat/server/upper)
+/turf/open/floor/catwalk_floor/iron_dark/airless,
+/area/space/nearstation)
 "qij" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -28049,8 +28178,9 @@
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/dark/corner,
 /obj/effect/turf_decal/siding/dark{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
@@ -28467,11 +28597,17 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "qyb" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/turf/open/floor/pod/dark,
-/area/station/tcommsat/server/upper)
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "qyl" = (
 /obj/structure/marker_beacon/burgundy,
 /obj/effect/turf_decal/trimline/dark_red/corner{
@@ -28756,6 +28892,9 @@
 	},
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 5
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium/airless,
 /area/space/nearstation)
@@ -29199,6 +29338,18 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/rd)
+"qQo" = (
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "qQA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/neutral,
@@ -29836,6 +29987,9 @@
 "rhG" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /turf/open/floor/pod/dark,
 /area/station/maintenance/aft/greater)
@@ -30941,14 +31095,14 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "rQu" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 10
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/turf/open/floor/engine/hull,
-/area/space/nearstation)
+/turf/open/floor/plating/airless,
+/area/station/science/ordnance/bomb)
 "rQv" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/siding/thinplating_new,
@@ -31320,9 +31474,17 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "sdg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/turf/open/floor/pod/dark,
-/area/station/tcommsat/server/upper)
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "sdl" = (
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -31578,7 +31740,7 @@
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/aft/greater)
 "siP" = (
@@ -33340,6 +33502,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/aft/greater)
@@ -33441,7 +33606,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/departments/telecomms/directional/south,
+/obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/aft/greater)
 "tfu" = (
@@ -34895,10 +35060,11 @@
 /turf/open/floor/plating,
 /area/centcom/asteroid/nearstation)
 "tUQ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/pod/dark,
-/area/station/maintenance/aft/greater)
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "tUW" = (
 /obj/structure/bed/dogbed,
 /turf/open/floor/carpet/green,
@@ -35586,6 +35752,14 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
+"uqp" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "uqO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/bot_red,
@@ -36206,9 +36380,7 @@
 /area/station/service/chapel)
 "uGn" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
 "uGu" = (
@@ -36520,9 +36692,13 @@
 	},
 /area/station/science/circuits)
 "uNI" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/dark,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor,
 /area/station/maintenance/aft/greater)
 "uNZ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -37071,8 +37247,7 @@
 	},
 /area/station/medical/pharmacy)
 "vcU" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/docking/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "vdu" = (
@@ -37234,6 +37409,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "vgA" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/aft/greater)
@@ -38946,11 +39125,8 @@
 /turf/open/floor/wood/tile,
 /area/station/service/cafeteria)
 "waC" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/dark{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
@@ -42486,15 +42662,17 @@
 	},
 /area/station/security/prison/mess)
 "xSj" = (
-/obj/machinery/door/airlock/engineering,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 8
 	},
-/turf/open/floor/pod/dark,
-/area/station/maintenance/aft/greater)
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "xSp" = (
 /obj/structure/sign/departments/aisat/directional/north,
 /obj/effect/spawner/random/engineering/tank,
@@ -42921,8 +43099,12 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/fore)
 "ydH" = (
-/turf/closed/wall,
-/area/station/tcommsat/server/upper)
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/engine/hull,
+/area/space/nearstation)
 "ydJ" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/reagent_dispensers/water_cooler,
@@ -118109,11 +118291,11 @@ oHa
 oHa
 hRo
 iJz
-swD
+rQu
 swD
 nkM
 tZs
-jUb
+eBm
 bwI
 hRo
 oHa
@@ -118625,7 +118807,7 @@ bwl
 hRo
 hRo
 rRC
-jUb
+nUA
 bjG
 hRo
 hRo
@@ -137148,7 +137330,7 @@ lEX
 lEX
 rFr
 tFq
-tFq
+vcU
 qly
 ewc
 tFq
@@ -137925,9 +138107,9 @@ esg
 esg
 wER
 oBJ
-oHa
-oHa
-oHa
+bwl
+bwl
+iAd
 oHa
 gcr
 oHa
@@ -138364,7 +138546,7 @@ nSP
 vBi
 wrr
 jyF
-bOj
+tUQ
 uIp
 tgb
 siI
@@ -138870,15 +139052,15 @@ oHa
 oHa
 jyF
 jyF
-bOj
+hdr
 bOj
 aBK
 ciX
 aBK
-bOj
+epF
 jyF
-bOj
-bOj
+daG
+rYf
 uIp
 ave
 jsN
@@ -138955,9 +139137,9 @@ wER
 oBJ
 jyF
 qli
-qli
-qli
-qli
+xSj
+xSj
+anh
 jyF
 jyF
 oHa
@@ -139126,7 +139308,7 @@ oHa
 oHa
 jyF
 jyF
-bOj
+daG
 wLO
 aBK
 wLO
@@ -139211,11 +139393,11 @@ esg
 wER
 oBJ
 jyF
-pEX
-pEX
-pEX
-pEX
-pEX
+byC
+qic
+qic
+gaN
+waC
 jyF
 jyF
 oHa
@@ -139468,12 +139650,12 @@ esg
 wER
 oBJ
 jyF
-pEX
-pEX
-pEX
-pEX
-pEX
-uGn
+gnm
+qyb
+qyb
+sdg
+qQo
+axS
 jyF
 oHa
 oHa
@@ -139726,10 +139908,10 @@ wER
 oBJ
 jyF
 jyF
+eJL
 jyF
 jyF
-jyF
-pEX
+bZg
 uGn
 jyF
 oHa
@@ -139982,13 +140164,13 @@ esg
 wER
 oBJ
 jyF
-pEX
-pEX
-pEX
+bSw
+aWV
+ncc
 jyF
 rro
 rro
-rro
+nRN
 oHa
 oHa
 oHa
@@ -140239,13 +140421,13 @@ wER
 wER
 aLm
 jyF
-epF
-waC
-rQu
+pEX
+pEX
+pEX
 jyF
 rro
 uYy
-lNx
+uqp
 pRz
 oHa
 oHa
@@ -140495,14 +140677,14 @@ kbP
 kbP
 kbP
 aLm
-aLm
-aLm
-nUA
-daG
+jyF
+pEX
+pEX
+pEX
 jyF
 rro
 uYy
-lNx
+uqp
 pgh
 oHa
 oHa
@@ -140746,20 +140928,20 @@ tEr
 fbM
 yhG
 tEr
-tEr
-tEr
-tEr
+omv
+omv
+ggy
 kVb
 hpl
-hpl
-tEr
 aLm
 aLm
-bSw
+pEX
+pEX
+pEX
 jyF
 rro
 uYy
-lNx
+uqp
 pgh
 oHa
 oHa
@@ -141004,19 +141186,19 @@ aLm
 pEU
 kKV
 wMw
-jxX
-jxX
 kdK
+kdK
+pJu
 odk
 omv
-hpl
-tEr
 aLm
+bSw
+aWV
 ncc
-ddn
-ddn
-ddn
+jyF
 rro
+rro
+dit
 oHa
 oHa
 oHa
@@ -141265,15 +141447,15 @@ aLm
 aLm
 aLm
 rhG
-kbP
-axS
-tEr
-vcU
-eBm
-ydH
+odk
+bHD
+jyF
+jyF
+jyF
+jyF
 bZg
-ddn
-ddn
+uGn
+jyF
 oHa
 oHa
 oHa
@@ -141480,7 +141662,7 @@ kqm
 kqm
 baB
 rKw
-bOj
+waC
 jyF
 oHa
 oHa
@@ -141522,15 +141704,15 @@ kPl
 kPl
 aLm
 siN
-aWV
-tUQ
 tEr
+bHD
+qli
 xSj
-sdg
+xSj
 pVa
 fqW
 eQs
-ddn
+jyF
 oHa
 oHa
 oHa
@@ -141737,7 +141919,7 @@ kqm
 syu
 dVA
 rKw
-bOj
+epF
 jyF
 oHa
 oHa
@@ -141778,16 +141960,16 @@ aGw
 aGw
 fBt
 aLm
-siN
-kbP
-gnm
-tfs
+vgA
+tEr
+aLm
+aLm
 aLm
 qic
 ydH
 mDb
-ddn
-ddn
+jyF
+jyF
 oHa
 oHa
 oHa
@@ -142036,14 +142218,14 @@ ueN
 ueN
 aLm
 mVe
-vgA
+omv
 uNI
-tEr
+tfs
 aLm
 qyb
 ddn
-ddn
-ddn
+jyF
+jyF
 oHa
 oHa
 oHa
@@ -142254,8 +142436,8 @@ wxW
 ehZ
 rKw
 qFt
-bOj
-bOj
+rYf
+rYf
 rBp
 ewJ
 reg
@@ -142297,8 +142479,8 @@ tdZ
 aLm
 fIQ
 aLm
-ddn
-ddn
+jyF
+jyF
 jyF
 oHa
 oHa
@@ -146136,8 +146318,8 @@ utK
 dcm
 oyo
 ino
-bOj
-bOj
+iBg
+iBg
 hYB
 hYB
 hYB
@@ -147112,7 +147294,7 @@ iBg
 cju
 duD
 duD
-hdr
+jxX
 jyF
 sYf
 sYf
@@ -147369,9 +147551,9 @@ duD
 lXb
 duD
 duD
-hdr
+jxX
 jyF
-bOj
+hdr
 sYf
 sYf
 sYf
@@ -147626,9 +147808,9 @@ duD
 lXb
 duD
 duD
-hdr
+jxX
 jyF
-bOj
+tUQ
 sYf
 sYf
 sYf
@@ -147883,7 +148065,7 @@ rYf
 uNn
 duD
 duD
-hdr
+jxX
 jyF
 jyF
 jyF
@@ -148140,7 +148322,7 @@ bOj
 aCB
 duD
 duD
-hdr
+jxX
 jyF
 oHa
 oHa


### PR DESCRIPTION
:cl:
fix: Foxhole no longer has a (now redundant) relay on the second deck.
/:cl: