### PR TITLE
Reintegrates Shark Plushie Into The Loadout + Batch Of Important Module Fixes

### DIFF
--- a/_maps/foxholestation.json
+++ b/_maps/foxholestation.json
@@ -11,13 +11,13 @@
     },
 	"traits": [
 		{
-			"Up": 1,
+			"Up": true,
 			"Linkage": "Cross"
 		},
 		{
-			"Linkage": "Cross",
-			"Down": -1,
-			"Baseturf": "/turf/open/openspace"
+			"Down": true,
+			"Baseturf": "/turf/open/openspace",
+			"Linkage": "Cross"
 		}
 	],
 	"job_changes": {

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -222,16 +222,16 @@
 			log_combat(thrown_by, M, "splashed", R)
 		reagents.expose(target, TOUCH, splash_multiplier)
 		reagents.expose(target_turf, TOUCH, (1 - splash_multiplier)) // 1 - splash_multiplier because it's what didn't hit the target
+		target_turf.add_liquid_from_reagents(reagents, reagent_multiplier = (1 - splash_multiplier)) /// EFFIGY EDIT - Liquids
 
 	else if(bartender_check(target) && thrown)
 		visible_message(span_notice("[src] lands onto the [target.name] without spilling a single drop."))
 		return
 
 	else
-		// EFFIGY EDIT CHANGE START
-		if(isturf(target))
-			var/turf/T = target
-			T.add_liquid_from_reagents(reagents)
+		// EFFIGY EDIT CHANGE START - Liquids
+		if(target.can_liquid_spill_on_hit())
+			target.add_liquid_from_reagents(reagents, thrown_from = src, thrown_to = target)
 			if(reagents.reagent_list.len && thrown_by)
 				log_combat(thrown_by, target, "splashed (thrown) [english_list(reagents.reagent_list)]", "in [AREACOORD(target)]")
 				log_game("[key_name(thrown_by)] splashed (thrown) [english_list(reagents.reagent_list)] on [target] in [AREACOORD(target)].")

--- a/local/code/datums/loadouts/loadout_datum_toys.dm
+++ b/local/code/datums/loadouts/loadout_datum_toys.dm
@@ -19,6 +19,10 @@ GLOBAL_LIST_INIT(loadout_toys, generate_loadout_items(/datum/loadout_item/toys))
 	name = "Carp Plushie"
 	item_path = /obj/item/toy/plush/carpplushie
 
+/datum/loadout_item/toys/shark
+	name = "Shark Plushie"
+	item_path = /obj/item/toy/plush/shark
+
 /datum/loadout_item/toys/lizard_greyscale
 	name = "Greyscale Lizard Plushie"
 	item_path = /obj/item/toy/plush/lizard_plushie

--- a/local/code/game/machinery/cryopod.dm
+++ b/local/code/game/machinery/cryopod.dm
@@ -234,7 +234,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 					stored_ckey = mob_occupant.mind.key // if mob does not have a ckey and was placed in cryo by someone else, we can get the key this way
 
 		var/mob/living/carbon/human/human_occupant = occupant
-		if(human_occupant && human_occupant.mind)
+		if(istype(human_occupant) && human_occupant.mind)
 			human_occupant.save_individual_persistence(stored_ckey)
 
 		COOLDOWN_START(src, despawn_world_time, time_till_despawn)

--- a/local/code/modules/lewd/lewd_arousal/climax.dm
+++ b/local/code/modules/lewd/lewd_arousal/climax.dm
@@ -7,6 +7,10 @@
 
 #define CLIMAX_NO_ESCAPE_ZONE 5
 
+/mob/living/carbon/human
+	/// Used to prevent nightmare scenarios.
+	var/refractory_period
+
 /mob/living/carbon/human/proc/climax(manual = TRUE)
 	if (CONFIG_GET(flag/disable_erp_preferences))
 		return
@@ -14,6 +18,9 @@
 	if(!client?.prefs?.read_preference(/datum/preference/toggle/erp/autocum) && !manual)
 		return
 
+	if(refractory_period > REALTIMEOFDAY)
+		return
+	refractory_period = REALTIMEOFDAY + 30 SECONDS
 	if(has_status_effect(/datum/status_effect/climax_cooldown) || !client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
 		return
 

--- a/local/code/modules/lewd/lewd_arousal/climax.dm
+++ b/local/code/modules/lewd/lewd_arousal/climax.dm
@@ -137,7 +137,7 @@
 						to_chat(target_human, span_userlove("Your [climax_into_choice] fills with warm cum as [src] shoots [self_their] load into it."))
 
 			var/obj/item/organ/external/genital/testicles/testicles = get_organ_slot(ORGAN_SLOT_TESTICLES)
-			testicles.reagents.remove_all(testicles.reagents.total_volume * 0.6)
+			testicles.transfer_internal_fluid(null, testicles.internal_fluid_count * 0.6) // yep. we are sending semen to nullspace
 			if(create_cum_decal)
 				add_cum_splatter_floor(get_turf(src))
 

--- a/local/code/modules/lewd/lewd_machinery/milking_machine.dm
+++ b/local/code/modules/lewd/lewd_machinery/milking_machine.dm
@@ -6,7 +6,7 @@
 #define MILKING_PUMP_STATE_OFF "off"
 #define MILKING_PUMP_STATE_ON "on"
 
-#define CLIMAX_RETRIVE_MULTIPLIER 2
+#define CLIMAX_RETRIEVE_MULTIPLIER 2
 #define MILKING_PUMP_MAX_CAPACITY 100
 
 /obj/structure/chair/milking_machine
@@ -360,7 +360,7 @@
 	if(pump_state != MILKING_PUMP_STATE_ON)
 		pump_state = MILKING_PUMP_STATE_ON
 
-	retrive_liquids_from_selected_organ(seconds_per_tick)
+	retrieve_liquids_from_selected_organ(seconds_per_tick)
 	increase_current_mob_arousal(seconds_per_tick)
 
 	update_all_visuals()
@@ -368,15 +368,15 @@
 
 // Liquid intake handler
 
-/obj/structure/chair/milking_machine/proc/retrive_liquids_from_selected_organ(seconds_per_tick)
+/obj/structure/chair/milking_machine/proc/retrieve_liquids_from_selected_organ(seconds_per_tick)
 	if(!current_mob || !current_selected_organ)
 		return FALSE
 
 	var/fluid_multiplier = 1
-	var/static/list/fluid_retrive_amount = list("off" = 0, "low" = 1, "medium" = 2, "hard" = 3)
+	var/static/list/fluid_retrieve_amount = list("off" = 0, "low" = 1, "medium" = 2, "hard" = 3)
 
 	if(current_mob.has_status_effect(/datum/status_effect/climax))
-		fluid_multiplier = CLIMAX_RETRIVE_MULTIPLIER
+		fluid_multiplier = CLIMAX_RETRIEVE_MULTIPLIER
 
 	var/obj/item/reagent_containers/target_container
 
@@ -388,10 +388,10 @@
 		if(/obj/item/organ/external/genital/testicles)
 			target_container = semen_vessel
 
-	if(!target_container || current_selected_organ.reagents.total_volume <= 0)
+	if(!target_container || current_selected_organ.internal_fluid_count <= 0)
 		return FALSE
 
-	current_selected_organ.transfer_internal_fluid(target_container.reagents, fluid_retrive_amount[current_mode] * fluid_multiplier * seconds_per_tick)
+	current_selected_organ.transfer_internal_fluid(target_container.reagents, fluid_retrieve_amount[current_mode] * fluid_multiplier * seconds_per_tick)
 	return TRUE
 
 // Handling the process of the impact of the machine on the organs of the mob
@@ -675,11 +675,12 @@
 		if (!beaker)
 			return FALSE
 
+		if(!current_vessel.reagents?.reagent_list.len)
+			return FALSE
+
 		var/amount = text2num(params["amount"])
 		current_vessel.reagents?.trans_to(beaker, amount)
-		current_vessel.reagents?.reagent_list[1].name
 		update_all_visuals()
-		to_chat(usr, span_notice("You transfer [amount] of [current_vessel.reagents?.reagent_list[1].name] to [beaker.name]"))
 		return TRUE
 
 /obj/structure/chair/milking_machine/examine(mob/user)
@@ -694,5 +695,5 @@
 #undef MILKING_PUMP_STATE_OFF
 #undef MILKING_PUMP_STATE_ON
 
-#undef CLIMAX_RETRIVE_MULTIPLIER
+#undef CLIMAX_RETRIEVE_MULTIPLIER
 #undef MILKING_PUMP_MAX_CAPACITY

--- a/local/code/modules/lewd/lewd_organs/_genital.dm
+++ b/local/code/modules/lewd/lewd_organs/_genital.dm
@@ -19,12 +19,13 @@
 /obj/item/organ/external/genital/proc/adjust_internal_fluid(amount)
 	internal_fluid_count = clamp(internal_fluid_count + amount, 0, internal_fluid_maximum)
 
-/// Tries to add the specified amount to the target reagent container. Keeps in mind internal_fluid_count.
-/obj/item/organ/external/genital/proc/transfer_internal_fluid(datum/reagents/reagent_container, attempt_amount)
-	if(!internal_fluid_datum || !internal_fluid_count || !internal_fluid_maximum || !reagent_container)
+/// Tries to add the specified amount to the target reagent container, or removes it if none are available. Keeps in mind internal_fluid_count.
+/obj/item/organ/external/genital/proc/transfer_internal_fluid(datum/reagents/reagent_container = null, attempt_amount)
+	if(!internal_fluid_datum || !internal_fluid_count || !internal_fluid_maximum)
 		return FALSE
 
 	attempt_amount = clamp(attempt_amount, 0, internal_fluid_count)
-	reagent_container.add_reagent(internal_fluid_datum, attempt_amount)
+	if(reagent_container)
+		reagent_container.add_reagent(internal_fluid_datum, attempt_amount)
 	internal_fluid_count -= attempt_amount
 

--- a/local/code/modules/lewd/lewd_quirks.dm
+++ b/local/code/modules/lewd/lewd_quirks.dm
@@ -259,7 +259,7 @@
 
 /datum/brain_trauma/very_special/sadism/on_life(seconds_per_tick, times_fired)
 	var/mob/living/carbon/human/affected_mob = owner
-	if(someone_suffering() && affected_mob.client?.prefs?.read_preference(/datum/preference/toggle/erp))
+	if(!owner.has_status_effect(/datum/status_effect/climax_cooldown) && affected_mob.client?.prefs?.read_preference(/datum/preference/toggle/erp) && someone_suffering())
 		affected_mob.adjust_arousal(2)
 		owner.add_mood_event("sadistic", /datum/mood_event/sadistic)
 	else

--- a/local/code/modules/liquids/liquid_systems/liquid_plumbers.dm
+++ b/local/code/modules/liquids/liquid_systems/liquid_plumbers.dm
@@ -254,7 +254,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/plumbing/floor_pump/input/on/waste, 0
 
 /obj/machinery/plumbing/floor_pump/output/should_regulator_permit(turf/affected_turf)
 	// 0 means keep pumping forever.
-	return !height_regulator || affected_turf.liquids.height < height_regulator
+	return (height_regulator == 0) || (affected_turf.liquids?.height < height_regulator)
 
 /obj/machinery/plumbing/floor_pump/output/process()
 	over_pressure = FALSE

--- a/local/code/modules/liquids/liquid_systems/liquid_turf.dm
+++ b/local/code/modules/liquids/liquid_systems/liquid_turf.dm
@@ -71,14 +71,82 @@
 
 	SSliquids.add_active_turf(src)
 
-/turf/proc/add_liquid_from_reagents(datum/reagents/giver, no_react = FALSE, reagent_multiplier = 1)
+/**
+ * Adds liquid to a turf from a given reagents list.
+ *
+ * Tries to add liquid to an atom's turf location. The atom could also be the turf itself.
+ * Calls add_liquid_list() on this turf if it exists.
+ *
+ * Arguments:
+ * * datum/reagents/giver - the reagents to add to the liquid_turf
+ * * no_react - whether or not we want to react immediately upon adding the reagents
+ * * reagent_multiplier - multiplies the individual reagents' volumes by this value
+ * * atom/thrown_from - the atom that the liquid is being thrown from (like a beaker). Null by default.
+ * * atom/thrown_target - the atom that the liquid is being thrown at. Null by default.
+ *
+ */
+/atom/proc/add_liquid_from_reagents(datum/reagents/giver, no_react = FALSE, reagent_multiplier = 1, atom/thrown_from = null, atom/thrown_to = null)
+	// if we are throwing something, see if we should bounce the liquid off the target atom
+	if(thrown_from)
+		var/turf/bounced_to = throw_back_liquid(thrown_from)
+		if(bounced_to)
+			giver.expose(thrown_to, TOUCH) // make sure we expose the hit target, since we aren't directly adding liquid there
+			bounced_to.add_liquid_from_reagents(giver, no_react, reagent_multiplier)
+			return
+
+	// otherwise business as usual
 	var/list/compiled_list = list()
 	for(var/r in giver.reagent_list)
 		var/datum/reagent/R = r
 		compiled_list[R.type] = R.volume * reagent_multiplier
 	if(!compiled_list.len) //No reagents to add, don't bother going further
 		return
-	add_liquid_list(compiled_list, no_react, giver.chem_temp)
+
+	// is this a turf?
+	var/turf/add_location = src
+	if(!isturf(add_location))
+		add_location = loc
+
+	// still can't find a turf? get out of here
+	if(!isturf(add_location))
+		return
+
+	add_location.add_liquid_list(compiled_list, no_react, giver.chem_temp)
+
+/**
+ * Bounces a thrown liquid off of a some object that has density.
+ *
+ * Finds an adjacent turf to bounce the liquid to.
+ *
+ * Arguments:
+ * * thrown_by - the mob throwing the atom that is doing the liquid spilling. Required.
+ *
+ * Returns: the found turf if there was one, null otherwise.
+ */
+/atom/proc/throw_back_liquid(atom/thrown_from)
+	if(!thrown_from || !density)
+		return
+
+	// first check the direction the throw came from
+	var/found_adjacent_turf = get_open_turf_in_dir(src, get_dir(src, thrown_from.loc))
+
+	if(found_adjacent_turf)
+		return found_adjacent_turf
+
+	// there might not be an open turf in that direction (someone stuck in a wall perhaps?) so try to get any adjacent open turf nearby
+	var/alternate_adjacent_turfs = get_adjacent_open_turfs(src)
+	if(!length(alternate_adjacent_turfs))
+		return
+
+	return pick(alternate_adjacent_turfs)
+
+/**
+ * Can liquid spills on this atom?
+ *
+ * Returns: TRUE or FALSE
+ */
+/atom/proc/can_liquid_spill_on_hit()
+	return isturf(src) || (flags_ricochet & RICOCHET_HARD) || !density
 
 //More efficient than add_liquid for multiples
 /turf/proc/add_liquid_list(reagent_list, no_react = FALSE, chem_temp = 300)

--- a/local/code/modules/mob/dead/new_player/sprite_accessories/synthliz.dm
+++ b/local/code/modules/mob/dead/new_player/sprite_accessories/synthliz.dm
@@ -77,6 +77,7 @@
 	color_src = USE_ONE_COLOR
 	name = "Synthetic Lizard"
 	icon_state = "synthliz"
+	flags_for_organ = SPRITE_ACCESSORY_WAG_ABLE
 	genetic = FALSE
 
 //Synth Antennae

--- a/local/code/modules/modular_implants/nif_persistence.dm
+++ b/local/code/modules/modular_implants/nif_persistence.dm
@@ -80,6 +80,13 @@
 	if(examine_component)
 		examine_component.nif_examine_text = persistence.nif_examine_text
 
+	var/obj/item/modular_computer/pda/found_pda = locate(/obj/item/modular_computer/pda) in contents
+	if(!found_pda)
+		return FALSE
+
+	var/datum/computer_file/program/nifsoft_downloader/downloaded_app = new
+	found_pda.store_file(downloaded_app)
+
 /// Loads the modular persistence data for a NIFSoft
 /datum/nifsoft/proc/load_persistence_data()
 	if(!linked_mob || !persistence)

--- a/local/code/modules/modular_implants/nifsoft_catalog.dm
+++ b/local/code/modules/modular_implants/nifsoft_catalog.dm
@@ -12,6 +12,7 @@ GLOBAL_LIST_INIT(purchasable_nifsofts, list(
 	filedesc = "NIFSoft Catalog"
 	extended_desc = "A virtual storefront that allows the user to install NIFSofts and purchase various NIF related products"
 	category = PROGRAM_CATEGORY_MISC
+	program_icon_state = "generic"
 	size = 3
 	tgui_id = "NtosNifsoftCatalog"
 	program_icon = "bag-shopping"

--- a/local/code/modules/modular_implants/nifsofts.dm
+++ b/local/code/modules/modular_implants/nifsofts.dm
@@ -70,7 +70,7 @@
 
 	linked_mob = null
 
-	var/obj/item/organ/internal/cyberimp/brain/nif/installed_nif = parent_nif.resolve()
+	var/obj/item/organ/internal/cyberimp/brain/nif/installed_nif = parent_nif?.resolve()
 	if(installed_nif)
 		installed_nif.loaded_nifsofts.Remove(src)
 
@@ -78,7 +78,11 @@
 
 /// Activates the parent NIFSoft
 /datum/nifsoft/proc/activate()
-	var/obj/item/organ/internal/cyberimp/brain/nif/installed_nif = parent_nif.resolve()
+	var/obj/item/organ/internal/cyberimp/brain/nif/installed_nif = parent_nif?.resolve()
+
+	if(!installed_nif)
+		stack_trace("NIFSoft [src] activated on a null parent!") // NIFSoft is -really- broken
+		return FALSE
 
 	if(installed_nif.broken)
 		installed_nif.balloon_alert(installed_nif.linked_mob, "your NIF is broken")
@@ -110,7 +114,9 @@
 
 ///Refunds the activation cost of a NIFSoft.
 /datum/nifsoft/proc/refund_activation_cost()
-	var/obj/item/organ/internal/cyberimp/brain/nif/installed_nif = parent_nif.resolve()
+	var/obj/item/organ/internal/cyberimp/brain/nif/installed_nif = parent_nif?.resolve()
+	if(!installed_nif)
+		return
 	installed_nif.change_power_level(-activation_cost)
 
 ///Removes the cooldown from a NIFSoft


### PR DESCRIPTION
Relevant PRs outlined in commit names. Changelog is an amalgam of all relevant with my own changes at the end.

:cl: vinylspiders, Iamgoofball, VastKilleroOm for Skyrat 13, unit0016
fix: fixed an issue that was causing climaxes to not complete if you possessed testicles, leading to being permanently horny in some cases
fix: fixes some runtimes with the milking machine
fix: Sadism quirk will now wait until the climax moodlet is gone before starting to add more arousal
fix: Buffs spacemen refractory period to reduce audio spam problems for players walking past dorms
fix: fixed a few things [Maintainer note: Synthliz tail now can wag again. Unsure why this was left default SR-side asides from language barrier.]
fix: fixed a bug with the liquid output pump's height regulator that was causing it to never output anything so long as a height was set
fix: changes to thrown liquid behavior--now they will ricochet off of walls and other dense objects and spill where the beaker lands instead of inside of the wall. [Maintainer note: Consequently this fixed liquid splashing down here entirely, oops. We missed a line.]
qol: The NIFSoft Catalog PDA app now automatically downloads itself roundstart if you have a NIF installed.
fix: The shark plushie is back. It sold out too soon.
fix: Your PDA no longer gets comedically white when you open the NIFSoft shop.
/:cl:
