### PR TITLE
OOPS. Fixes Foxhole Central Primary Lighting

### DIFF
--- a/_maps/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/map_files/FoxHoleStation/foxholestation.dmm
@@ -23873,6 +23873,15 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
+"nPK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "nQs" = (
 /obj/effect/turf_decal/tile/bar/diagonal_edge,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -72112,7 +72121,7 @@ vfH
 uGP
 bTz
 rCA
-rCA
+nPK
 jCa
 rCA
 rCA


### PR DESCRIPTION
:cl:
fix: The area outside Foxhole's Bar is no longer dark enough to spook a [player reference]. Oops.
/:cl:

