### PR TITLE
Remove dormant SQL game logging

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -22,6 +22,15 @@
  */
 #define DB_MINOR_VERSION 24
 
+/**
+ * DB Effigy schema version
+ *
+ * Update this whenever the db schema changes
+ *
+ * make sure you add an update to the schema_version stable in the db changelog
+ */
+#define DB_EFFIGY_VERSION 4  // EffigyEdit Add
+
 
 //! ## Timing subsystem
 /**

--- a/code/__HELPERS/logging/_logging.dm
+++ b/code/__HELPERS/logging/_logging.dm
@@ -98,24 +98,7 @@ GLOBAL_LIST_INIT(testing_global_profiler, list("_PROFILE_NAME" = "Global"))
 /atom/proc/log_message(message, message_type, color = null, log_globally = TRUE)
 	if(!log_globally)
 		return
-	// EFFIGY EDIT ADD START (#3 Logging - Ported from Skyrat)
-	#ifndef SPACEMAN_DMM
-	if(CONFIG_GET(flag/sql_game_log) && CONFIG_GET(flag/sql_enabled))
-		SSdbcore.add_log_to_mass_insert_queue(
-			format_table_name("game_log"),
-			list(
-				"datetime" = SQLtime(),
-				"round_id" = "[GLOB.round_id]",
-				"ckey" = key_name(src),
-				"loc" = loc_name(src),
-				"type" = message_type,
-				"message" = message,
-			)
-		)
-		if(!CONFIG_GET(flag/file_game_log))
-			return
-	#endif
-	// EFFIGY EDIT ADD END (#3 Logging - Ported from Skyrat)
+
 	var/log_text = "[key_name(src)] [message] [loc_name(src)]"
 	switch(message_type)
 		/// ship both attack logs and victim logs to the end of round attack.log just to ensure we don't lose information

--- a/code/_globalvars/_effigy/config.dm
+++ b/code/_globalvars/_effigy/config.dm
@@ -1,22 +1,6 @@
 /// LOOC Module
 GLOBAL_VAR_INIT(looc_allowed, TRUE)
 
-/// Whether or not we log game logs to the SQL database. Requires the SQL database to function, as well as our Skyrat-only table, `game_log`.
-/datum/config_entry/flag/sql_game_log
-	protection = CONFIG_ENTRY_LOCKED
-
-/// Whether or not we log game logs to files on the server when we're already logging them on the server, if SQL_GAME_LOG is enabled.
-/datum/config_entry/flag/file_game_log
-	protection = CONFIG_ENTRY_LOCKED
-
-/// The minimum amount of entries there should be in the list of game logs for a mass query to be sent to the database.
-/// Depends on SQL_GAME_LOG being enabled, doesn't mean anything otherwise.
-/// Setting this to a value that's too low risks to severely affect perceptible performance, due to a high amount of
-/// sleeps being involved with running queries.
-/datum/config_entry/number/sql_game_log_min_bundle_size
-	default = 100
-	min_val = 1
-
 /// Upper value for random events at highpop.
 /datum/config_entry/number/event_frequency_upper
 	default = 14 MINUTES

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -39,11 +39,6 @@ SUBSYSTEM_DEF(dbcore)
 
 	var/db_daemon_started = FALSE
 
-	/// An associative list of list of rows to add to a database table with the name of the target table as a key.
-	/// Used to queue up log entries for bigger queries that happen less often, to reduce the strain on the server caused by
-	/// hundreds of additional queries constantly trying to run.
-	var/list/queued_log_entries_by_table = list() // EFFIGY EDIT ADD
-
 /datum/controller/subsystem/dbcore/Initialize()
 	//We send warnings to the admins during subsystem init, as the clients will be New'd and messages
 	//will queue properly with goonchat
@@ -179,11 +174,6 @@ SUBSYSTEM_DEF(dbcore)
 	if(SSdbcore.Connect())
 		for(var/datum/db_query/query in queries_standby)
 			run_query(query)
-
-		// EFFIGY EDIT ADD START (#3 Logging - Ported from Skyrat)
-		for(var/table in queued_log_entries_by_table)
-			MassInsert(table, rows = queued_log_entries_by_table[table], duplicate_key = FALSE, ignore_errors = FALSE, delayed = FALSE, warn = FALSE, async = TRUE, special_columns = null)
-		// EFFIGY EDIT ADD END (#3 Logging - Ported from Skyrat)
 
 		var/datum/db_query/query_round_shutdown = SSdbcore.NewQuery(
 			"UPDATE [format_table_name("round")] SET effigy_rid = :effigy_rid, shutdown_datetime = Now(), end_state = :end_state WHERE id = :round_id",
@@ -654,41 +644,3 @@ Delayed insert mode was removed in mysql 7 and only works with MyISAM type table
 /datum/db_query/proc/Close()
 	rows = null
 	item = null
-
-// EFFIGY EDIT ADD START
-/**
- * This is a proc to hopefully mitigate the effect of a large influx of queries needing to be created
- * for something like SQL-based game logs. The goal here is to bundle a certain amount of those log
- * entries together (default is 100, but it depends on the `SQL_GAME_LOG_MIN_BUNDLE_SIZE` config
- * entry) before sending them, so that we can massively reduce the amount of lag associated with
- * logging so many entries to the database.
- *
- * Arguments:
- * * table - The name of the table to insert the log enty into.
- * * log_entry - Associative list representing all of the information that needs to be logged.
- * Default format is as follows, for the `game_log` table (even if this could be used for another table):
- * 	list(
- * 		"datetime" = SQLtime(),
- * 		"round_id" = "[GLOB.round_id]",
- * 		"ckey" = key_name(src),
- * 		"loc" = loc_name(src),
- * 		"type" = message_type,
- * 		"message" = message,
- * 	)
- * Take a look at `/atom/proc/log_message()` for an example of implementation.
- */
-/datum/controller/subsystem/dbcore/proc/add_log_to_mass_insert_queue(table, log_entry)
-	if(IsAdminAdvancedProcCall())
-		return
-
-	if(!queued_log_entries_by_table[table])
-		queued_log_entries_by_table[table] = list()
-
-	queued_log_entries_by_table[table] += list(log_entry)
-
-	if(length(queued_log_entries_by_table[table]) < CONFIG_GET(number/sql_game_log_min_bundle_size))
-		return
-
-	INVOKE_ASYNC(src, PROC_REF(MassInsert), table, /*rows =*/ queued_log_entries_by_table[table], /*duplicate_key =*/ FALSE, /*ignore_errors =*/ FALSE, /*delayed =*/ FALSE, /*warn =*/ FALSE, /*async =*/ TRUE, /*special_columns =*/ null)
-	queued_log_entries_by_table -= table
-// EFFIGY EDIT ADD END

--- a/config/effigy_config.txt
+++ b/config/effigy_config.txt
@@ -1,15 +1,3 @@
-# Whether or not we log game logs to the SQL database. Requires the SQL database to function, as well as our Skyrat-only table, `game_log`.
-#SQL_GAME_LOG
-
-# Whether or not we log game logs to files on the server when we're already logging them on the server, if SQL_GAME_LOG is enabled.
-FILE_GAME_LOG
-
-# The minimum amount of entries there should be in the list of game logs for a mass query to be sent to the database.
-# Depends on SQL_GAME_LOG being enabled, doesn't mean anything otherwise.
-# Setting this to a value that's too low risks to severely affect perceptible performance, due to a high amount of
-# sleeps being involved with running queries.
-SQL_GAME_LOG_MIN_BUNDLE_SIZE 100
-
 ## Use Effigy Game Services API
 # USE_EFFIGY_API
 


### PR DESCRIPTION
## About The Pull Request

Removes the SQL game logging setup used by Skyrat

## Why It's Good For The Game

While we used to use it, we have our own logging method now.

## Changelog

:cl: LT3
server: Removed Skyrat related logging code
/:cl: