### PR TITLE
[PORT] Fixes Quickspawn/SimpleTF/genetics eating mutcols

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -594,7 +594,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 /datum/preferences/proc/safe_transfer_prefs_to(mob/living/carbon/human/character, icon_updates = TRUE, is_antag = FALSE)
 	apply_character_randomization_prefs(is_antag)
 	apply_prefs_to(character, icon_updates)
-	INVOKE_ASYNC(src, PROC_REF(apply_prefs_to_sleepy), character, icon_updates) // EffigyEdit Add - Resolve timing issues related to delayed pref addition
 
 /// Applies the given preferences to a human mob.
 /datum/preferences/proc/apply_prefs_to(mob/living/carbon/human/character, icon_updates = TRUE, visuals_only = FALSE)

--- a/local/code/datums/dna.dm
+++ b/local/code/datums/dna.dm
@@ -170,15 +170,15 @@
 
 	var/features = dna.unique_features
 	if(dna.features["mcolor"])
-		dna.features["mcolor"] = sanitize_hexcolor(get_uni_identity_block(features, DNA_MUTANT_COLOR_BLOCK))
+		dna.features["mcolor"] = sanitize_hexcolor(get_uni_feature_block(features, DNA_MUTANT_COLOR_BLOCK))
 	if(dna.features["mcolor2"])
-		dna.features["mcolor2"] = sanitize_hexcolor(get_uni_identity_block(features, DNA_MUTANT_COLOR_2_BLOCK))
+		dna.features["mcolor2"] = sanitize_hexcolor(get_uni_feature_block(features, DNA_MUTANT_COLOR_2_BLOCK))
 	if(dna.features["mcolor3"])
-		dna.features["mcolor3"] = sanitize_hexcolor(get_uni_identity_block(features, DNA_MUTANT_COLOR_3_BLOCK))
+		dna.features["mcolor3"] = sanitize_hexcolor(get_uni_feature_block(features, DNA_MUTANT_COLOR_3_BLOCK))
 	if(dna.features["ethcolor"])
-		dna.features["ethcolor"] = sanitize_hexcolor(get_uni_identity_block(features, DNA_ETHEREAL_COLOR_BLOCK))
+		dna.features["ethcolor"] = sanitize_hexcolor(get_uni_feature_block(features, DNA_ETHEREAL_COLOR_BLOCK))
 	if(dna.features["skin_color"])
-		dna.features["skin_color"] = sanitize_hexcolor(get_uni_identity_block(features, DNA_SKIN_COLOR_BLOCK))
+		dna.features["skin_color"] = sanitize_hexcolor(get_uni_feature_block(features, DNA_SKIN_COLOR_BLOCK))
 
 	if(icon_update)
 		if(mutcolor_update)

--- a/local/code/modules/client/preferences.dm
+++ b/local/code/modules/client/preferences.dm
@@ -49,13 +49,6 @@
 	/// A photo of the character, visible on close examine
 	var/headshot = ""
 
-/**
- * A wrapper function for apply_prefs_to to use asynchronously when timing wonkiness happens.
-*/
-/datum/preferences/proc/apply_prefs_to_sleepy(mob/living/carbon/human/character, icon_updates = TRUE, visuals_only = FALSE, delay = 1)
-	sleep(delay)
-	apply_prefs_to(character, icon_updates, visuals_only)
-
 /datum/preferences/proc/species_updated(species_type)
 	all_quirks = list()
 	// Reset cultural stuff


### PR DESCRIPTION
## Original PR: https://github.com/Skyrat-SS13/Skyrat-tg/pull/23061

:cl: CliffracerX
fix: mutantcolors are being pulled from your features dna again, no more pink feathers!
/:cl: