### PR TITLE
lowpop maint access

### DIFF
--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -161,23 +161,25 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/keycard_auth, 26)
 			toggle_bluespace_artillery()
 
 GLOBAL_VAR_INIT(emergency_access, FALSE)
-/proc/make_maint_all_access()
+/proc/make_maint_all_access(silent = FALSE) // EffigyEdit Change - Add silent var
 	for(var/area/station/maintenance/A in GLOB.areas)
 		for(var/turf/in_area as anything in A.get_contained_turfs())
 			for(var/obj/machinery/door/airlock/D in in_area)
 				D.emergency = TRUE
 				D.update_icon(ALL, 0)
-	minor_announce("Access restrictions on maintenance and external airlocks have been lifted.", "Attention! Station-wide emergency declared!",1)
+	if(!silent) // EffigyEdit Change - Add silent var
+		minor_announce("Access restrictions on maintenance and external airlocks have been lifted.", "Access Announcement",1)  // EffigyEdit Change - Remove emergency declaration
 	GLOB.emergency_access = TRUE
 	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("emergency maintenance access", "enabled"))
 
-/proc/revoke_maint_all_access()
+/proc/revoke_maint_all_access(silent = FALSE)
 	for(var/area/station/maintenance/A in GLOB.areas)
 		for(var/turf/in_area as anything in A.get_contained_turfs())
 			for(var/obj/machinery/door/airlock/D in in_area)
 				D.emergency = FALSE
 				D.update_icon(ALL, 0)
-	minor_announce("Access restrictions in maintenance areas have been restored.", "Attention! Station-wide emergency rescinded:")
+	if(!silent) // EffigyEdit Change - Add silent var
+		minor_announce("Access restrictions in maintenance areas have been restored.", "Access Announcement") // EffigyEdit Change - Remove emergency declaration
 	GLOB.emergency_access = FALSE
 	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("emergency maintenance access", "disabled"))
 

--- a/local/code/controllers/subsystem/job.dm
+++ b/local/code/controllers/subsystem/job.dm
@@ -6,3 +6,11 @@
 	if(!job)
 		return FALSE
 	job.current_positions = max(0, job.current_positions - 1)
+
+/datum/controller/subsystem/job/DivideOccupations()
+	. = ..()
+
+	var/lowpop = (length(GLOB.clients) <= CONFIG_GET(number/minimal_access_threshold))
+	if(lowpop)
+		log_game("Activating maintenance expanded access due to skeleton crew")
+		make_maint_all_access(silent = TRUE)


### PR DESCRIPTION
## About The Pull Request

If the server pop is below the lowpop number in config, round starts with maint access enabled.

:cl: LT3
qol: Maintenance access now enabled on lowpop rounds
/:cl: