### PR TITLE
Fix a bad vomit call in synthanol mob life

### DIFF
--- a/local/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/local/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -31,7 +31,7 @@
 	if(!(C.mob_biotypes & MOB_ROBOTIC))
 		C.reagents.remove_reagent(type, 3.6) //gets removed from organics very fast
 		if(prob(25))
-			C.vomit(5, FALSE, FALSE)
+			C.vomit(VOMIT_CATEGORY_DEFAULT)
 	return ..()
 
 /datum/reagent/consumable/ethanol/synthanol/expose_mob(mob/living/carbon/C, method=TOUCH, volume)


### PR DESCRIPTION

## About The Pull Request

This vomit call hasn't been updated since the vomit refactor got merged
## Why It's Good For The Game

fix good vomit not good
## Changelog
:cl:
fix: Organic creatures will now vomit correctly when drinking synth drinks again.
/:cl:
