### PR TITLE
Add bitrunners back to cybernetic revolutions again

### DIFF
--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -283,8 +283,9 @@
 		/datum/job/assistant = /obj/item/organ/internal/heart/cybernetic, //real cardiac
 		/datum/job/atmospheric_technician = /obj/item/organ/internal/cyberimp/mouth/breathing_tube,
 		/datum/job/bartender = /obj/item/organ/internal/liver/cybernetic/tier3,
-		/datum/job/broadcast_team = /obj/item/organ/internal/eyes/robotic/glow, // EFFIGY EDIT Add - Broadcast Team
+		/datum/job/bitrunner = /obj/item/organ/internal/eyes/robotic/thermals,
 		/datum/job/botanist = /obj/item/organ/internal/cyberimp/chest/nutriment,
+		/datum/job/broadcast_team = /obj/item/organ/internal/eyes/robotic/glow, // EFFIGY EDIT Add - Broadcast Team
 		/datum/job/captain = /obj/item/organ/internal/heart/cybernetic/tier3,
 		/datum/job/cargo_technician = /obj/item/organ/internal/stomach/cybernetic/tier2,
 		/datum/job/chaplain = /obj/item/organ/internal/cyberimp/brain/anti_drop,


### PR DESCRIPTION

## About The Pull Request

Git must have accidentally overwrote incoming changes with local ones because the line looked similar. 
## Why It's Good For The Game

fix great cybers cool
## Changelog
:cl:
fix: Bitrunners now partake in cybernetic revolutions again.
/:cl:
