### PR TITLE
Removes empty `icon_for` implementation from unused body markings preferences

### DIFF
--- a/local/code/modules/client/preferences/_preference.dm
+++ b/local/code/modules/client/preferences/_preference.dm
@@ -125,6 +125,10 @@
 
 // icons are cached
 /datum/preference/choiced/mutant_choice/icon_for(value)
+	if(!should_generate_icons)
+		// because of the way the unit tests are set up, we need this to crash here
+		CRASH("`icon_for()` was not implemented for [type], even though should_generate_icons = TRUE!")
+
 	var/list/cached_icons = get_choices()
 	return cached_icons[value]
 

--- a/local/code/modules/client/preferences/mutant_parts.dm
+++ b/local/code/modules/client/preferences/mutant_parts.dm
@@ -66,9 +66,6 @@
 	type_to_check = /datum/preference/toggle/mutant_toggle/body_markings
 	default_accessory_type = /datum/sprite_accessory/body_markings/none
 
-/datum/preference/choiced/mutant_choice/body_markings/icon_for(value)
-	return
-
 /datum/preference/choiced/mutant_choice/body_markings/is_accessible(datum/preferences/preferences)
 	. = ..() // Got to do this because of linters.
 	return FALSE


### PR DESCRIPTION

## About The Pull Request

As quoted by Julius Caesar himself: 

https://github.com/effigy-se/effigy-se/blob/3933e78f79ab495b19cdffd5204f5dc1a6c6c3fa/local/code/modules/client/preferences/mutant_parts.dm#L49

Doesn't make sense for it to constantly fail CI then
## Why It's Good For The Game

less mean circle more do
## Changelog
nothing playerfacing
