### PR TITLE
Remove duplicate pipes in icebox broadcasting studio

### DIFF
--- a/_maps/templates/automapper/icebox/icebox_broadcast_studio.dmm
+++ b/_maps/templates/automapper/icebox/icebox_broadcast_studio.dmm
@@ -322,8 +322,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/studio,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/landmark/navigate_destination,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
 	},


### PR DESCRIPTION

## About The Pull Request

Duplicate pipes under the door to the icebox broadcasting studio caused mapping failures
## Why It's Good For The Game

less error more good
## Changelog
:cl:
fix: Removes duplicate pipes in icebox broadcasting studio.
/:cl:
