### PR TITLE
Fix alien optable not numbing patients

### DIFF
--- a/code/modules/antagonists/abductor/abductor_structures.dm
+++ b/code/modules/antagonists/abductor/abductor_structures.dm
@@ -91,6 +91,9 @@
 	if(iscarbon(AM))
 		START_PROCESSING(SSobj, src)
 		to_chat(AM, span_danger("You feel a series of tiny pricks!"))
+	// EffigyEdit Addition Start - Call mark_patient
+	mark_patient(src, AM)
+	// EffigyEdit Addition End
 
 /obj/structure/table/optable/abductor/process(seconds_per_tick)
 	. = PROCESS_KILL


### PR DESCRIPTION

## About The Pull Request

Alien optables override a signal from their parent, which leads to `chill_out` not being called
Fixes #411
## Why It's Good For The Game

numbing good less pain
## Changelog
:cl:
fix: Alien operating tables will now numb people properly again.
/:cl:
