### PR TITLE
Rimpoint Morgue Fix

### DIFF
--- a/_maps/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/map_files/RimPoint/RimPoint.dmm
@@ -6700,7 +6700,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/west,
-/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron,
 /area/station/medical/morgue)
 "dbR" = (


### PR DESCRIPTION
:cl:
fix: You can access the MortiDrobe again.
/:cl:
