### PR TITLE
TG Update - Cargo Parity, Railing Fixes

### DIFF
--- a/_maps/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/map_files/FoxHoleStation/foxholestation.dmm
@@ -4975,6 +4975,11 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/maintenance/port/central)
+"cJO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/smooth,
+/area/station/cargo/warehouse)
 "cJW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -23022,11 +23027,15 @@
 /obj/structure/cable,
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/storage/box/bandages{
+	pixel_y = 6;
+	pixel_x = 4
+	},
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/cargo/storage)
 "mWf" = (
@@ -140100,7 +140109,7 @@ ctm
 uyY
 wUB
 hKS
-iZZ
+cJO
 vZY
 mhY
 vcB

--- a/_maps/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/map_files/RimPoint/RimPoint.dmm
@@ -2412,9 +2412,13 @@
 /area/station/commons/toilet/restrooms)
 "bis" = (
 /obj/structure/table/reinforced,
+/obj/machinery/light/directional/west,
+/obj/item/storage/box/bandages{
+	pixel_y = 6;
+	pixel_x = 4
+	},
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/belt/utility,
-/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "biu" = (


### PR DESCRIPTION
Updates Foxhole and Rimpoint to have parity with other maps' cargo - IE, bandages.

There also appears to be an issue with railings but I think that's.. uhh.
Going to be addressed upstream? Maybe?