### PR TITLE
Add the lore-accurate weighted dice

### DIFF
--- a/local/code/datums/loadouts/loadout_datum_toys.dm
+++ b/local/code/datums/loadouts/loadout_datum_toys.dm
@@ -217,6 +217,10 @@ GLOBAL_LIST_INIT(loadout_toys, generate_loadout_items(/datum/loadout_item/toys))
 	name = "D20"
 	item_path = /obj/item/dice/d20
 
+/datum/loadout_item/toys/d20/nat1
+	name = "D20 (weighted on 1)"
+	item_path = /obj/item/dice/d20/nat1
+
 /datum/loadout_item/toys/d100
 	name = "D100"
 	item_path = /obj/item/dice/d100

--- a/local/code/game/objects/items/dice.dm
+++ b/local/code/game/objects/items/dice.dm
@@ -1,0 +1,4 @@
+/obj/item/dice/d20/nat1
+	desc = "A die with twenty sides. This one fills you with powerlessness."
+	rigged = DICE_BASICALLY_RIGGED
+	rigged_value = 1

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5969,6 +5969,7 @@
 #include "local\code\game\objects\effects\landmarks.dm"
 #include "local\code\game\objects\effects\decals\turfdecal\markings.dm"
 #include "local\code\game\objects\items\cards_ids.dm"
+#include "local\code\game\objects\items\dice.dm"
 #include "local\code\game\objects\items\hairbrush.dm"
 #include "local\code\game\objects\items\holocigarette.dm"
 #include "local\code\game\objects\items\plushes.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds a lore accurate dice to loadouts

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

its hilarious

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added a weighted d20 to player loadouts. It's not favorable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
