### PR TITLE
Module Mirror Maintenance

### DIFF
--- a/code/__DEFINES/_effigy/medical_defines.dm
+++ b/code/__DEFINES/_effigy/medical_defines.dm
@@ -8,3 +8,8 @@
 
 #define COMSIG_BODYPART_SPLINTED "bodypart_splinted" // from /obj/item/bodypart/proc/apply_gauze(/obj/item/stack/gauze)
 #define COMSIG_BODYPART_SPLINT_DESTROYED "bodypart_desplinted" // from [/obj/item/bodypart/proc/seep_gauze] when it runs out of absorption
+
+/// If a synth is revived via defib, they will have a brain trauma for this amount of time.
+#define SYNTH_DEFIBBED_TRAUMA_DURATION 90 SECONDS
+/// If a synth is revived via defib, they will get a brain trauma of this severity.
+#define SYNTH_DEFIBBED_TRAUMA_SEVERITY BRAIN_TRAUMA_SEVERE

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -578,6 +578,13 @@
 	do_cancel()
 
 /obj/item/shockpaddles/proc/do_help(mob/living/carbon/H, mob/living/user)
+	/// EFFIGY EDIT BEGIN - Synthetic Defibrillator Handling ///
+	var/target_synthetic = (user.mob_biotypes & MOB_ROBOTIC)
+	if (target_synthetic)
+		to_chat(user, span_boldwarning("[H] is a synthetic lifeform! This defibrillator probably isn't calibrated to revive [H.p_them()] properly and could have some serious consequences! \
+		[span_warning("You might want to [span_blue("surgically revive [H.p_them()]")]...")]"))
+		balloon_alert(user, "target is synthetic!") // immediately grabs their attention even if they dont see chat
+	/// EFFIGY EDIT END - Synthetic Defibrillator Handling ///
 	user.visible_message(span_warning("[user] begins to place [src] on [H]'s chest."), span_warning("You begin to place [src] on [H]'s chest..."))
 	busy = TRUE
 	update_appearance()
@@ -663,6 +670,22 @@
 					else
 						user.add_mood_event("saved_life", /datum/mood_event/saved_life)
 					log_combat(user, H, "revived", defib)
+					/// EFFIGY EDIT BEGIN - Synthetic Defibrillator Handling ///
+					if (target_synthetic)
+						user.visible_message(span_boldwarning("[src] fire a powerful jolt of electricity into [H]'s vulnerable circuitry!"))
+						to_chat(H, span_userdanger("[user]'s defibrillator fires a powerful jolt of electricity into your vulnerable circuitry, overloading it!"))
+						// You may ask, why not just call H.emp_act()?
+						// well my dear reader, that EMPs contents. I only want to EMP bodyparts and organs specifically
+						for (var/obj/item/bodypart/iterated_part as anything in H.bodyparts)
+							iterated_part.emp_act(EMP_LIGHT)
+						for (var/obj/item/organ/iterated_organ as anything in H.organs)
+							iterated_organ.emp_act(EMP_LIGHT)
+						var/obj/item/organ/internal/brain/brain_organ = H.get_organ_slot(ORGAN_SLOT_BRAIN)
+						if (istype(brain_organ))
+							var/datum/brain_trauma/trauma = brain_organ.gain_trauma_type(SYNTH_DEFIBBED_TRAUMA_SEVERITY, TRAUMA_LIMIT_BASIC)
+							if (!QDELETED(trauma))
+								addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(remove_synth_defib_trauma), brain_organ, trauma), SYNTH_DEFIBBED_TRAUMA_DURATION)
+					/// EFFIGY EDIT END - Synthetic Defibrillator Handling ///
 				do_success()
 				return
 			else if (!H.get_organ_by_type(/obj/item/organ/internal/heart))

--- a/local/code/game/machinery/dna_fixer.dm
+++ b/local/code/game/machinery/dna_fixer.dm
@@ -124,7 +124,7 @@
 
 	use_power(500)
 
-/// Ejects the occupant as either their preference character, or as a monke based on emag status.
+/// Ejects the occupant after asking them if they want to accept the rejuvenation. If yes, they exit as their preferences character.
 /obj/machinery/dna_fixer/proc/eject_new_you()
 	if(state_open || !occupant || !powered())
 		return
@@ -132,21 +132,36 @@
 
 	if(!ishuman(occupant))
 		return FALSE
+	var/mob/living/carbon/human/human_occupant = occupant
 
-	var/mob/living/carbon/human/patient = occupant
-	var/original_name = patient.dna.real_name
+	var/failure = FALSE
+	var/failure_text
 
-	patient.client?.prefs?.safe_transfer_prefs_to_with_damage(patient)
-	patient.dna.update_dna_identity()
-	log_game("[key_name(patient)] used a Healixir at [loc_name(src)].")
+	if (!isnull(human_occupant.ckey) && isnull(human_occupant.client)) // player mob, currently disconnected
+		failure = TRUE
+		failure_text = "ERROR: Treatment elicited no response from occupant genes. Subject may be suffering from Sudden Sleep Disorder."
+	else if (tgui_alert(occupant, "The SAD you are within is about to rejuvenate you, resetting your body to its default state (in character preferences). Do you consent?", "Rejuvenate", list("Yes", "No"), timeout = 10 SECONDS) != "Yes")
+		failure = TRUE // defaults to rejecting it unless specified otherwise
+		failure_text = "ERROR: Occupant genes have willfully rejected the procedure. You may try again if you think this was an error."
 
-	if(patient.dna.real_name != original_name)
-		message_admins("[key_name_admin(patient)] has used the Healixir, and changed the name of their character. \
-		Original Name: [original_name], New Name: [patient.dna.real_name]. \
-		This may be a false positive from changing from a humanized monkey into a character, so be careful.")
+	if (failure)
+		say(failure_text)
+		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
+	else
+		var/mob/living/carbon/human/patient = occupant
+		var/original_name = patient.dna.real_name
+
+		patient.client?.prefs?.safe_transfer_prefs_to_with_damage(patient)
+		patient.dna.update_dna_identity()
+		log_game("[key_name(patient)] used a Self-Actualization Device at [loc_name(src)].")
+
+		if(patient.dna.real_name != original_name)
+			message_admins("[key_name_admin(patient)] has used the Self-Actualization Device, and changed the name of their character. \
+			Original Name: [original_name], New Name: [patient.dna.real_name]. \
+			This may be a false positive from changing from a humanized monkey into a character, so be careful.")
+		playsound(src, 'sound/machines/microwave/microwave-end.ogg', 100, FALSE)
 
 	open_machine()
-	playsound(src, 'sound/machines/microwave/microwave-end.ogg', 100, FALSE)
 
 /obj/machinery/dna_fixer/screwdriver_act(mob/living/user, obj/item/used_item)
 	. = TRUE

--- a/local/code/game/machinery/washing_machine.dm
+++ b/local/code/game/machinery/washing_machine.dm
@@ -1,0 +1,49 @@
+/obj/machinery/washing_machine
+	can_buckle = TRUE
+	/// If we are active, all mobs buckled to us with a penis will have arousal raised by this per second.
+	var/buckled_arousal_penis = 0.5
+	/// If we are active, all mobs buckled to us with a vagina will have arousal raised by this per second.
+	var/buckled_arousal_vagina = 2
+	/// If we are active and anchored, our arousal given to buckled mobs will be multiplied against this.
+	var/anchored_arousal_mult = 0.25
+
+/obj/machinery/washing_machine/process(seconds_per_tick)
+	. = ..()
+	if (. == PROCESS_KILL)
+		return
+
+	if (!LAZYLEN(buckled_mobs))
+		return
+
+	for (var/mob/living/carbon/human/buckled_human in buckled_mobs)
+		if (!buckled_human.client?.prefs?.read_preference(/datum/preference/toggle/erp))
+			continue
+
+		var/covered = FALSE
+		for (var/obj/item/clothing/iter_clothing in buckled_human.get_all_worn_items())
+			if (!(iter_clothing.body_parts_covered & GROIN))
+				continue
+			if (iter_clothing.clothing_flags & THICKMATERIAL)
+				covered = TRUE
+				break
+
+		if (covered)
+			continue
+
+		var/obj/item/organ/external/genital/vagina/found_vagina = buckled_human.get_organ_slot(ORGAN_SLOT_VAGINA)
+		var/obj/item/organ/external/genital/vagina/found_penis = buckled_human.get_organ_slot(ORGAN_SLOT_PENIS)
+
+		var/arousal_mult = seconds_per_tick
+		var/message_chance = 40
+		if (anchored)
+			arousal_mult *= anchored_arousal_mult
+			message_chance *= anchored_arousal_mult
+		var/do_message = FALSE
+		if (!isnull(found_vagina))
+			buckled_human.adjust_arousal(buckled_arousal_vagina * arousal_mult)
+			do_message = TRUE
+		if (!isnull(found_penis))
+			buckled_human.adjust_arousal(buckled_arousal_penis * arousal_mult)
+			do_message = TRUE
+		if (do_message && SPT_PROB(message_chance, seconds_per_tick))
+			to_chat(buckled_human, span_userlove("[src] vibrates into your groin, and you feel a warm fuzzy feeling..."))

--- a/local/code/game/objects/items/defib.dm
+++ b/local/code/game/objects/items/defib.dm
@@ -1,0 +1,12 @@
+/**
+ * Global timer proc used in defib.dm. Removes the temporary trauma caused by being defibbed as a synth.
+ *
+ * Args:
+ * * obj/item/organ/internal/brain/synth_brain: The brain with the trauma on it. Non-nullable.
+ * * datum/brain_trauma/trauma: The trauma itself. Non-nullable.
+ */
+/proc/remove_synth_defib_trauma(obj/item/organ/internal/brain/synth_brain, datum/brain_trauma/trauma)
+	if (QDELETED(synth_brain) || QDELETED(trauma))
+		return
+
+	QDEL_NULL(trauma)

--- a/local/code/modules/client/augment/limbs.dm
+++ b/local/code/modules/client/augment/limbs.dm
@@ -10,15 +10,16 @@
 		var/obj/item/bodypart/new_limb = path
 		var/body_zone = initial(new_limb.body_zone)
 		var/obj/item/bodypart/old_limb = augmented.get_bodypart(body_zone)
+
+		old_limb.limb_id = initial(new_limb.limb_id)
+		old_limb.base_limb_id = initial(new_limb.limb_id)
+		old_limb.is_dimorphic = initial(new_limb.is_dimorphic)
+
 		if(uses_robotic_styles && prefs.augment_limb_styles[slot])
 			var/chosen_style = GLOB.robotic_styles_list[prefs.augment_limb_styles[slot]]
-			old_limb.limb_id = initial(new_limb.limb_id)
-			old_limb.base_limb_id = initial(new_limb.limb_id)
 			old_limb.set_icon_static(chosen_style)
 			old_limb.current_style = prefs.augment_limb_styles[slot]
 		else
-			old_limb.limb_id = initial(new_limb.limb_id)
-			old_limb.base_limb_id = initial(new_limb.limb_id)
 			old_limb.set_icon_static(initial(new_limb.icon))
 		old_limb.should_draw_greyscale = FALSE
 
@@ -30,6 +31,8 @@
 			var/chosen_style = GLOB.robotic_styles_list[prefs.augment_limb_styles[slot]]
 			new_limb.set_icon_static(chosen_style)
 			new_limb.current_style = prefs.augment_limb_styles[slot]
+		for (var/obj/item/organ/external/external_organ as anything in old_limb.external_organs)
+			external_organ.transfer_to_limb(new_limb)
 		new_limb.replace_limb(augmented)
 		qdel(old_limb)
 

--- a/local/code/modules/client/preferences/middleware/limbs_and_markings.dm
+++ b/local/code/modules/client/preferences/middleware/limbs_and_markings.dm
@@ -39,8 +39,8 @@
 		"r_arm" = TRUE,
 		"l_leg" = TRUE,
 		"r_leg" = TRUE,
-		"chest" = FALSE, // TODO: figure out why head/chest augs dont render, needed for IPC head on non IPC body
-		"head" = FALSE,
+		"chest" = TRUE,
+		"head" = TRUE,
 		"l_hand" = FALSE,
 		"r_hand" = FALSE,
 	)
@@ -71,9 +71,7 @@
 	if(!visuals_only)
 		return
 
-	// If you ever add chest and head augments, please add the body zones to this list.
-	// Removing them for now for optimization purposes.
-	for(var/body_zone in list(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG))
+	for(var/body_zone in list(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_CHEST, BODY_ZONE_HEAD))
 		if(body_zone in visited_body_zones)
 			continue
 

--- a/local/code/modules/clothing/suits/misc.dm
+++ b/local/code/modules/clothing/suits/misc.dm
@@ -253,6 +253,9 @@
 	icon_state = "don_cossak"
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
+/obj/item/clothing/suit/costume/ghost_sheet
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+
 /obj/item/clothing/suit/corgisuit/en
 	name = "\improper super-hero E-N suit"
 	icon = 'local/icons/obj/clothing/suits.dmi'

--- a/local/code/modules/modular_implants/nifs.dm
+++ b/local/code/modules/modular_implants/nifs.dm
@@ -508,6 +508,7 @@
 	new /obj/item/disk/nifsoft_uploader/summoner(src)
 	new /obj/item/disk/nifsoft_uploader/money_sense(src)
 	new /obj/item/disk/nifsoft_uploader/dorms(src)
+	new /obj/item/disk/nifsoft_uploader/dorms/hypnosis(src)
 	new /obj/item/disk/nifsoft_uploader/soulcatcher(src)
 
 #undef NIF_CALIBRATION_STAGE_1

--- a/local/code/modules/modular_implants/nifsofts/dorms.dm
+++ b/local/code/modules/modular_implants/nifsofts/dorms.dm
@@ -1,12 +1,12 @@
 /obj/item/disk/nifsoft_uploader/dorms
-	name = "Grimoire Inceptum"
+	name = "Grimoire Libidine"
 	loaded_nifsoft = /datum/nifsoft/summoner/dorms
 
 /datum/nifsoft/summoner/dorms
-	name = "Grimoire Inceptum"
-	program_desc = "Grimoire Inceptum, a fork of the Grimoire Caeruleam code, allows users to conveniently access an extensive database of various adult toys. "
+	name = "Grimoire Libidine"
+	program_desc = "Grimoire Libidine, a fork of the Grimoire Caeruleam code, allows users to conveniently access an extensive database of various adult toys. "
 	holographic_filter = FALSE //No RGB toys
-	name_tag = "inceptum "
+	name_tag = "Libidine "
 	lewd_nifsoft = TRUE
 	ui_icon = "heart"
 
@@ -62,7 +62,7 @@
 	purchase_price = 150
 
 /obj/item/disk/nifsoft_uploader/dorms/contract
-	name = "\improper Inceptum Contract"
+	name = "\improper Libidine Contract"
 	loaded_nifsoft = /datum/nifsoft/hypno
 	reusable = TRUE //This is set to true because of how this handles updating laws
 	///What laws will be assigned when using the NIFSoft on someone?
@@ -93,8 +93,8 @@
 	return TRUE
 
 /datum/nifsoft/hypno
-	name = "Inceptum Contract"
-	program_desc = "Once installed, the Inceptum Contract compells the user to follow the rules stored in the data of the NIFSoft. \n OOC NOTE: This is strictly here for adult roleplay. None of the laws here actually need to be obeyed and you can uninstall this NIFSoft at any time."
+	name = "Libidine Contract"
+	program_desc = "Once installed, the Libidine Contract compells the user to follow the rules stored in the data of the NIFSoft. \n OOC NOTE: This is strictly here for adult roleplay. None of the laws here actually need to be obeyed and you can uninstall this NIFSoft at any time."
 	purchase_price = 0
 	lewd_nifsoft = TRUE
 	ui_icon = "file-contract"

--- a/local/code/modules/modular_implants/nifsofts/hypnosis.dm
+++ b/local/code/modules/modular_implants/nifsofts/hypnosis.dm
@@ -1,10 +1,10 @@
 /obj/item/disk/nifsoft_uploader/dorms/hypnosis
-	name = "Inceptum Eye"
+	name = "Libidine Eye"
 	loaded_nifsoft = /datum/nifsoft/action_granter/hypnosis
 
 /datum/nifsoft/action_granter/hypnosis
-	name = "Inceptum Eye"
-	program_desc = "Based on the hypnotic equipment provided by the LustWish vendor, the inceptum eyes NIFSoft allows the user to ensnare others in a hypnotic trance. ((This is intended as a tool for ERP, don't use this for gameplay reasons.))"
+	name = "Libidine Eye"
+	program_desc = "Based on the hypnotic equipment provided by the LustWish vendor, the Libidine eyes NIFSoft allows the user to ensnare others in a hypnotic trance. ((This is intended as a tool for ERP, don't use this for gameplay reasons.))"
 	buying_category = NIFSOFT_CATEGORY_FUN
 	lewd_nifsoft = TRUE
 	purchase_price = 150

--- a/local/code/modules/modular_implants/nifsofts/hypnosis.dm
+++ b/local/code/modules/modular_implants/nifsofts/hypnosis.dm
@@ -1,3 +1,7 @@
+/obj/item/disk/nifsoft_uploader/dorms/hypnosis
+	name = "Inceptum Eye"
+	loaded_nifsoft = /datum/nifsoft/action_granter/hypnosis
+
 /datum/nifsoft/action_granter/hypnosis
 	name = "Inceptum Eye"
 	program_desc = "Based on the hypnotic equipment provided by the LustWish vendor, the inceptum eyes NIFSoft allows the user to ensnare others in a hypnotic trance. ((This is intended as a tool for ERP, don't use this for gameplay reasons.))"

--- a/local/code/modules/research/medical_designs.dm
+++ b/local/code/modules/research/medical_designs.dm
@@ -11,3 +11,13 @@
 		/datum/material/silver = SHEET_MATERIAL_AMOUNT,
 	)
 	build_path = /obj/item/rsd_interface
+
+/datum/design/surgery/healing/robotic_healing_upgrade
+	name = "Repair robotic limbs upgrade: Advanced"
+	surgery = /datum/surgery/robot_healing/upgraded
+	id = "robotic_heal_surgery_upgrade"
+
+/datum/design/surgery/healing/robotic_healing_upgrade_2
+	name = "Repair robotic limbs upgrade: Experimental"
+	surgery = /datum/surgery/robot_healing/experimental
+	id = "robotic_heal_surgery_upgrade_2"

--- a/local/code/modules/research/techweb/all_nodes.dm
+++ b/local/code/modules/research/techweb/all_nodes.dm
@@ -1,0 +1,19 @@
+/datum/techweb_node/improved_robotic_tend_wounds
+	id = "improved_robotic_surgery"
+	display_name = "Improved Robotic Repair Surgeries"
+	description = "As it turns out, you don't actually need to cut out entire support rods if it's just scratched!"
+	prereq_ids = list("engineering")
+	design_ids = list(
+		"robotic_heal_surgery_upgrade"
+	)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 900)
+
+/datum/techweb_node/advanced_robotic_tend_wounds
+	id = "advanced_robotic_surgery"
+	display_name = "Advanced Robotic Surgeries"
+	description = "Did you know Hephaestus actually has a free online tutorial for synthetic trauma repairs? It's true!"
+	prereq_ids = list("improved_robotic_surgery")
+	design_ids = list(
+		"robotic_heal_surgery_upgrade_2"
+	)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1300) // less expensive than the organic surgery research equivalent since its JUST tend wounds

--- a/local/code/modules/surgery/robot_healing.dm
+++ b/local/code/modules/surgery/robot_healing.dm
@@ -122,6 +122,9 @@
 		other_message += " as best as they can while [target] has clothing on"
 
 	target.heal_bodypart_damage(healed_brute, healed_burn, 0, BODYTYPE_ROBOTIC)
+
+	self_message += get_progress(user, target, healed_brute, healed_burn)
+
 	display_results(user, target, span_notice("[self_message]."), "[other_message].", "[other_message].")
 
 	if(istype(surgery, /datum/surgery/robot_healing))
@@ -157,19 +160,90 @@
 
 /***************************TYPES***************************/
 /datum/surgery/robot_healing/basic
-	name = "Repair robotic limbs (basic)"
+	name = "Repair robotic limbs (Basic)"
 	healing_step_type = /datum/surgery_step/robot_heal/basic
 	desc = "A surgical procedure that provides repairs and maintenance to robotic limbs. Is slightly more efficient when the patient is severely damaged."
-	replaced_by = null
+	healing_step_type = /datum/surgery_step/robot_heal/basic
+	replaced_by = /datum/surgery/robot_healing/upgraded
+
+/datum/surgery/robot_healing/upgraded
+	name = "Repair robotic limbs (Adv.)"
+	desc = "A surgical procedure that provides highly effective repairs and maintenance to robotic limbs. Is somewhat more efficient when the patient is severely damaged."
+	healing_step_type = /datum/surgery_step/robot_heal/upgraded
+	replaced_by = /datum/surgery/robot_healing/experimental
+	requires_tech = TRUE
+
+/datum/surgery/robot_healing/experimental
+	name = "Repair robotic limbs (Exp.)"
+	desc = "A surgical procedure that quickly provides highly effective repairs and maintenance to robotic limbs. Is moderately more efficient when the patient is severely damaged."
+	healing_step_type = /datum/surgery_step/robot_heal/experimental
+	replaced_by = /datum/surgery/robot_healing/experimental
+	requires_tech = TRUE
 
 /***************************STEPS***************************/
 
 /datum/surgery_step/robot_heal/basic
-	name = "repair damage"
 	brute_heal_amount = 10
 	burn_heal_amount = 10
 	missing_health_bonus = 15
-	time = 10
+	time = 2.5 SECONDS
+
+/datum/surgery_step/robot_heal/upgraded
+	brute_heal_amount = 12
+	burn_heal_amount = 12
+	missing_health_bonus = 11
+	time = 2.3 SECONDS
+
+/datum/surgery_step/robot_heal/experimental
+	brute_heal_amount = 14
+	burn_heal_amount = 14
+	missing_health_bonus = 8
+	time = 2 SECONDS
+
+// Mostly a copypaste of standard tend wounds get_progress(). In order to abstract this, I'd have to rework the hierarchy of surgery upstream, so I'll just do this. Pain.
+/**
+ * Args:
+ * * mob/user: The user performing this surgery.
+ * * mob/living/carbon/target: The target of the surgery.
+ * * brute_healed: The amount of brute we just healed.
+ * * burn_healed: The amount of burn we just healed.
+ *
+ * Returns:
+ * * A string containing either an estimation of how much longer the surgery will take, or exact numbers of the remaining damages, depending on if a health analyzer
+ * is held or not.
+ */
+/datum/surgery_step/robot_heal/proc/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
+	var/estimated_remaining_steps = 0
+	if(brute_healed > 0)
+		estimated_remaining_steps = max(0, (target.getBruteLoss() / brute_healed))
+	if(burn_healed > 0)
+		estimated_remaining_steps = max(estimated_remaining_steps, (target.getFireLoss() / burn_healed)) // whichever is higher between brute or burn steps
+
+	var/progress_text
+
+	if(locate(/obj/item/healthanalyzer) in user.held_items)
+		if(target.getBruteLoss())
+			progress_text = ". Remaining brute: <font color='#ff3333'>[target.getBruteLoss()]</font>"
+		if(target.getFireLoss())
+			progress_text += ". Remaining burn: <font color='#ff9933'>[target.getFireLoss()]</font>"
+	else
+		switch(estimated_remaining_steps)
+			if(-INFINITY to 1)
+				return
+			if(1 to 3)
+				progress_text = ", finishing up the last few signs of damage"
+			if(3 to 6)
+				progress_text = ", counting down the last few patches of trauma"
+			if(6 to 9)
+				progress_text = ", continuing to plug away at [target.p_their()] extensive damages"
+			if(9 to 12)
+				progress_text = ", steadying yourself for the long surgery ahead"
+			if(12 to 15)
+				progress_text = ", though [target.p_they()] still look[target.p_s()] heavily battered"
+			if(15 to INFINITY)
+				progress_text = ", though you feel like you're barely making a dent in treating [target.p_their()] broken body"
+
+	return progress_text
 
 #undef DAMAGE_ROUNDING
 #undef FAIL_DAMAGE_MULTIPLIER

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6020,6 +6020,7 @@
 #include "local\code\game\objects\effects\landmarks.dm"
 #include "local\code\game\objects\effects\decals\turfdecal\markings.dm"
 #include "local\code\game\objects\items\cards_ids.dm"
+#include "local\code\game\objects\items\defib.dm"
 #include "local\code\game\objects\items\dice.dm"
 #include "local\code\game\objects\items\hairbrush.dm"
 #include "local\code\game\objects\items\holocigarette.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6505,6 +6505,7 @@
 #include "local\code\modules\research\designs.dm"
 #include "local\code\modules\research\mechfabricator_designs.dm"
 #include "local\code\modules\research\medical_designs.dm"
+#include "local\code\modules\research\techweb\all_nodes.dm"
 #include "local\code\modules\splash\new_player.dm"
 #include "local\code\modules\splash\screen_control.dm"
 #include "local\code\modules\splash\splash_html.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6008,6 +6008,7 @@
 #include "local\code\game\machinery\drone_dispenser.dm"
 #include "local\code\game\machinery\light.dm"
 #include "local\code\game\machinery\machinery.dm"
+#include "local\code\game\machinery\washing_machine.dm"
 #include "local\code\game\machinery\camera\camera.dm"
 #include "local\code\game\machinery\camera\presets.dm"
 #include "local\code\game\machinery\computer\camera.dm"


### PR DESCRIPTION
Synth QOL, Renaming, Blahblah.

## Changelog
:cl: nikothedude, softcerv, honkpocket for Skyrat 13
balance: Synth tend wounds repeatable step now takes 2.5 seconds from 1
balance: 2 new synth tend wounds upgrades available to research
fix: Synth tend wounds now gives proper feedback
balance: Defibrilators now EMP synths and apply a temporary brain trauma for 90 seconds to them
balance: Synth revival surgery time and steps vastly reduced/streamlined
fix: the ghost role NIF boxes now contain the Purpura Eye NIFSoft
qol: SAD patients can now reject the treatment at the last step, preventing any changes from being made
fix: Chest/Heads can now be augmented in the augment menu
add: You can now buckle yourself to washing machines! This serves no practical purpose except for FUN TIMES.
fix: fixed ghost bedsheet wearable being an error sprite on digitigrade legged characters
spellcheck: renames the purpura NIFSofts to libidine
/:cl:
