### PR TITLE
Opens The Gates Of Hades: Part One, Just The Ruin Datums

### DIFF
--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -69,8 +69,6 @@
 
 // above and below ground together
 
-// EFFIGY EDIT REMOVE START (#3 Mapping)
-/*
 /datum/map_template/ruin/icemoon/mining_site
 	name = "Mining Site"
 	id = "miningsite"
@@ -86,8 +84,6 @@
 	suffix = "icemoon_underground_mining_site.dmm"
 	has_ceiling = FALSE
 	unpickable = TRUE
-*/
-// EFFIGY EDIT REMOVE END (#3 Mapping)
 
 // below ground only
 

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -51,15 +51,10 @@
 	id = "ash-walker"
 	description = "A race of unbreathing lizards live here, that run faster than a human can, worship a broken dead city, and are capable of reproducing by something involving tentacles? \
 	Probably best to stay clear."
-	// EFFIGY EDIT CHANGE START (#3 Customization - Ported from Skyrat)
-	prefix = "_maps/RandomRuins/LavaRuins/skyrat/"
-	suffix = "lavaland_surface_ash_walker1_skyrat.dmm"
-	always_place = TRUE
-	// EFFIGY EDIT CHANGE END (#3 Customization - Ported from Skyrat)
+	suffix = "lavaland_surface_ash_walker1.dmm"
+	cost = 20
 	allow_duplicates = FALSE
 
-// EFFIGY EDIT REMOVE START (#3 Customization - Ported from Skyrat)
-/*
 /datum/map_template/ruin/lavaland/syndicate_base
 	name = "Syndicate Lava Base"
 	id = "lava-base"
@@ -67,8 +62,6 @@
 	suffix = "lavaland_surface_syndicate_base1.dmm"
 	cost = 20
 	allow_duplicates = FALSE
-*/
-// EFFIGY EDIT REMOVE END (#3 Customization - Ported from Skyrat)
 
 /datum/map_template/ruin/lavaland/free_golem
 	name = "Free Golem Ship"

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -179,7 +179,7 @@
 
 /datum/map_template/ruin/space/spacehotel
 	id = "spacehotel"
-	suffix = "spacehotel_skyrat.dmm"	// EFFIGY EDIT CHANGE (#3 Mapping - Ported from Skyrat)
+	suffix = "spacehotel.dmm"
 	name = "The Twin-Nexus Hotel"
 	description = "An interstellar hotel, where the weary spaceman can rest their head and relax, assured that the residental staff will not murder them in their sleep. Probably."
 


### PR DESCRIPTION
Okay, so. This PR's gonna have some fallout assuming some config tweaks aren't enabled on the box.
This re-enables every /tg/ ruin accidentally disabled by #3. Only one of these isn't a ghostrole.

Whilst we've been *avoiding* letting people play ghostroles as to (rightfully) keep our pop from being split up so early, we've already had a few people remaking their statics on assumption (and proclamations by some of our own otherwise), and it's my grand duty as ~~ruby miller~~ a maintainer to cede to the tiniest bit of pressure and open the flood gates. Codewise only. Config it's anyone's game.

One problem, if we're actually going to canonize having ghostroles this early instead of disabling these config-side until we need to have them.
We don't have the code for handling prefs on ghostroles ported here, and I'm not in the mood to go on a scavenger hunt for it.
So.. here we are instead. Just the ruin datum part.
Uh.
Lol.
:cl:
fix: Icemoon Godkiller armor is now obtainable again, and the Frost Miner is now fightable. Again.
/:cl:
