### PR TITLE
Enable flipping

### DIFF
--- a/local/code/modules/mob/living/emotes/emotes.dm
+++ b/local/code/modules/mob/living/emotes/emotes.dm
@@ -61,12 +61,6 @@
 		return 'local/sound/emotes/generic/female/female_sneeze.ogg'
 	return
 
-/datum/emote/flip/can_run_emote(mob/user, status_check, intentional)
-	if(intentional && !HAS_TRAIT(user, TRAIT_FREERUNNING) && !isobserver(user))
-		user.balloon_alert(user, "not nimble enough!")
-		return FALSE
-	return ..()
-
 /datum/emote/living/peep
 	key = "peep"
 	key_third_person = "peeps"


### PR DESCRIPTION
## About The Pull Request

Blocking flipping was accidentally ported from Skyrat. Fixes that!

## Why It's Good For The Game

Our players have the freedom to flip if they so choose.

## Changelog

:cl: LT3
balance: The shackles preventing you from flipping have been removed
/:cl: