### PR TITLE
Hopefully fix liquid bleedthrough, once and for all

### DIFF
--- a/local/code/modules/liquids/liquid_systems/liquid_controller.dm
+++ b/local/code/modules/liquids/liquid_systems/liquid_controller.dm
@@ -17,15 +17,22 @@ SUBSYSTEM_DEF(liquids)
 	var/list/processing_fire = list()
 	var/fire_counter = 0 //Only process fires on intervals
 
+	// format: list[path, list[str, instance]]
 	var/list/singleton_immutables = list()
 
 	var/run_type = SSLIQUIDS_RUN_TYPE_TURFS
 
-/datum/controller/subsystem/liquids/proc/get_immutable(type)
-	if(!singleton_immutables[type])
-		var/obj/effect/abstract/liquid_turf/immutable/new_one = new type()
-		singleton_immutables[type] = new_one
-	return singleton_immutables[type]
+/datum/controller/subsystem/liquids/proc/get_immutable(type, turf/reference_turf)
+	if(isnull(singleton_immutables[type]))
+		singleton_immutables[type] = list()
+
+	var/offset = GET_TURF_PLANE_OFFSET(reference_turf)
+
+	if(!("[offset]" in singleton_immutables[type]))
+		var/obj/effect/abstract/liquid_turf/immutable/new_one = new type(null, offset)
+		singleton_immutables[type]["[offset]"] = new_one
+
+	return singleton_immutables[type]["[offset]"]
 
 
 /datum/controller/subsystem/liquids/stat_entry(msg)

--- a/local/code/modules/liquids/liquid_systems/liquid_effect.dm
+++ b/local/code/modules/liquids/liquid_systems/liquid_effect.dm
@@ -4,8 +4,12 @@
 	icon_state = "water-0"
 	base_icon_state = "water"
 	anchored = TRUE
-	plane = FLOOR_PLANE
-	layer = ABOVE_OPEN_TURF_LAYER
+
+	layer = FLY_LAYER
+	plane = ABOVE_GAME_PLANE
+	appearance_flags = TILE_BOUND
+	vis_flags = NONE
+
 	color = "#DDF"
 
 	//For being on fire
@@ -653,17 +657,15 @@
 	smoothing_flags = NONE
 	icon_state = "ocean"
 	base_icon_state = "ocean"
-	plane = WALL_PLANE //Same as weather, etc.
-	layer = OBJ_LAYER
 	starting_temp = T20C-150
 	no_effects = TRUE
-	vis_flags = NONE
 
 /obj/effect/abstract/liquid_turf/immutable/ocean/warm
 	starting_temp = T20C+20
 
-/obj/effect/abstract/liquid_turf/immutable/Initialize(mapload)
+/obj/effect/abstract/liquid_turf/immutable/Initialize(mapload, plane_offset)
 	. = ..()
+	SET_PLANE_W_SCALAR(src, initial(plane), plane_offset)
 	reagent_list = starting_mixture.Copy()
 	total_reagents = 0
 	for(var/key in reagent_list)

--- a/local/code/modules/liquids/liquid_systems/liquid_effect.dm
+++ b/local/code/modules/liquids/liquid_systems/liquid_effect.dm
@@ -4,11 +4,9 @@
 	icon_state = "water-0"
 	base_icon_state = "water"
 	anchored = TRUE
-
-	layer = FLY_LAYER
-	plane = ABOVE_GAME_PLANE
+	plane = FLOOR_PLANE
+	layer = ABOVE_OPEN_TURF_LAYER
 	appearance_flags = TILE_BOUND
-	vis_flags = NONE
 
 	color = "#DDF"
 
@@ -657,6 +655,8 @@
 	smoothing_flags = NONE
 	icon_state = "ocean"
 	base_icon_state = "ocean"
+	layer = FLY_LAYER
+	plane = ABOVE_GAME_PLANE
 	starting_temp = T20C-150
 	no_effects = TRUE
 

--- a/local/code/modules/liquids/ocean_turfs.dm
+++ b/local/code/modules/liquids/ocean_turfs.dm
@@ -28,7 +28,7 @@
 			liquids.remove_turf(src)
 		else
 			qdel(liquids, TRUE)
-	var/obj/effect/abstract/liquid_turf/immutable/new_immmutable = SSliquids.get_immutable(/obj/effect/abstract/liquid_turf/immutable/ocean)
+	var/obj/effect/abstract/liquid_turf/immutable/new_immmutable = SSliquids.get_immutable(/obj/effect/abstract/liquid_turf/immutable/ocean, src)
 	new_immmutable.add_turf(src)
 
 /turf/open/misc/ironsand/ocean
@@ -42,7 +42,7 @@
 			liquids.remove_turf(src)
 		else
 			qdel(liquids, TRUE)
-	var/obj/effect/abstract/liquid_turf/immutable/new_immmutable = SSliquids.get_immutable(/obj/effect/abstract/liquid_turf/immutable/ocean)
+	var/obj/effect/abstract/liquid_turf/immutable/new_immmutable = SSliquids.get_immutable(/obj/effect/abstract/liquid_turf/immutable/ocean, src)
 	new_immmutable.add_turf(src)
 
 
@@ -101,7 +101,7 @@
 			liquids.remove_turf(src)
 		else
 			qdel(liquids, TRUE)
-	var/obj/effect/abstract/liquid_turf/immutable/new_immmutable = SSliquids.get_immutable(liquid_type)
+	var/obj/effect/abstract/liquid_turf/immutable/new_immmutable = SSliquids.get_immutable(liquid_type, src)
 	new_immmutable.add_turf(src)
 
 	if(rand_variants && prob(rand_chance))
@@ -120,7 +120,7 @@
 			liquids.remove_turf(src)
 		else
 			qdel(liquids, TRUE)
-	var/obj/effect/abstract/liquid_turf/immutable/new_immmutable = SSliquids.get_immutable(/obj/effect/abstract/liquid_turf/immutable/ocean)
+	var/obj/effect/abstract/liquid_turf/immutable/new_immmutable = SSliquids.get_immutable(/obj/effect/abstract/liquid_turf/immutable/ocean, src)
 	new_immmutable.add_turf(src)
 
 /turf/open/floor/iron/ocean
@@ -134,7 +134,7 @@
 			liquids.remove_turf(src)
 		else
 			qdel(liquids, TRUE)
-	var/obj/effect/abstract/liquid_turf/immutable/new_immmutable = SSliquids.get_immutable(/obj/effect/abstract/liquid_turf/immutable/ocean)
+	var/obj/effect/abstract/liquid_turf/immutable/new_immmutable = SSliquids.get_immutable(/obj/effect/abstract/liquid_turf/immutable/ocean, src)
 	new_immmutable.add_turf(src)
 
 /turf/closed/mineral/random/ocean
@@ -181,7 +181,7 @@
 			liquids.remove_turf(src)
 		else
 			qdel(liquids, TRUE)
-	var/obj/effect/abstract/liquid_turf/immutable/new_immmutable = SSliquids.get_immutable(/obj/effect/abstract/liquid_turf/immutable/canal)
+	var/obj/effect/abstract/liquid_turf/immutable/new_immmutable = SSliquids.get_immutable(/obj/effect/abstract/liquid_turf/immutable/canal, src)
 	new_immmutable.add_turf(src)
 
 /turf/open/misc/canal_mutable


### PR DESCRIPTION
## About The Pull Request

This PR creates an extra list of liquid overlays with modified planes that match the requesting turf's Z-level. Hopefully this fixes this stupid bleedthrough error once and for all. I sat on this idea for weeks unsure if it would work until Lemon basically confirmed that this idea has been tried and tested and pointing me to gas overlay code.

## Why It's Good For The Game

bleedthrough sucks for ocean maps
Fixes #213 
## Changelog
:cl:
fix: Water from levels below will no longer appear as if they were above the current level's turf.
/:cl:
