### PR TITLE
Effigy CSS adjustments

### DIFF
--- a/local/code/datums/level_datums.dm
+++ b/local/code/datums/level_datums.dm
@@ -5,6 +5,7 @@
  */
 /datum/security_level/white
 	name = "white"
+	announcement_color = "default"
 	number_level = SEC_LEVEL_WHITE
 	sound = 'sound/misc/notice2.ogg'
 	lowering_to_configuration_key = /datum/config_entry/string/alert_white_downto
@@ -18,6 +19,7 @@
  */
 /datum/security_level/magenta
 	name = "magenta"
+	announcement_color = "pink"
 	number_level = SEC_LEVEL_MAGENTA
 	sound = 'sound/misc/notice2.ogg'
 	lowering_to_configuration_key = /datum/config_entry/string/alert_magenta_downto
@@ -31,6 +33,7 @@
  */
 /datum/security_level/yellow
 	name = "yellow"
+	announcement_color = "yellow"
 	number_level = SEC_LEVEL_YELLOW
 	sound = 'sound/misc/notice1.ogg'
 	lowering_to_configuration_key = /datum/config_entry/string/alert_yellow_downto
@@ -44,6 +47,7 @@
  */
 /datum/security_level/orange
 	name = "orange"
+	announcement_color = "orange"
 	number_level = SEC_LEVEL_ORANGE
 	sound = 'sound/misc/notice1.ogg'
 	lowering_to_configuration_key = /datum/config_entry/string/alert_orange_downto

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -925,72 +925,52 @@ em {
   color: #ffd861;
 }
 
-.major_announcement_title {
-  color: #ff0066;
-  text-decoration: underline;
-  font-weight: bold;
-  font-size: 175%;
-}
-
-.major_announcement_text {
-  color: #eaeaea;
-  font-weight: bold;
-  font-size: 125%;
-}
-
-.minor_announcement_title {
-  color: #33d5ff;
-  font-weight: bold;
-  font-size: 150%;
-}
-
-.minor_announcement_text {
-  color: #eaeaea;
-  font-size: 125%;
-}
-
 $alert-stripe-colors: (
-  'default': #00283a,
+  // EffigyEdit Change
+  'default': #252525,
   'green': #003d00,
   'blue': #00283a,
   'pink': #30001b,
   'yellow': #574a00,
   'orange': #593400,
   'red': #420000,
-  'purple': #2c0030,
+  'purple': #2c0030
 );
 
 $alert-stripe-alternate-colors: (
-  'default': #003045,
+  // EffigyEdit Change
+  'default': #292929,
   'green': #004700,
   'blue': #003045,
   'pink': #400025,
   'yellow': #4d4100,
   'orange': #6b4200,
   'red': #520000,
-  'purple': #38003d,
+  'purple': #38003d
 );
 
 $alert-major-header-colors: (
-  'default': #33d5ff,
+  // EffigyEdit Change
+  'default': #ff4791,
   'green': #00ff80,
   'blue': #33d5ff,
   'pink': #ff80b3,
   'yellow': #fff4e0,
   'orange': #feefe7,
   'red': #ffa8c4,
-  'purple': #c7a1f7,
+  'purple': #c7a1f7
 );
 
 $alert-subheader-header-colors: (
-  'default': #ff9ebb,
+  // EffigyEdit Change
+  'default': #33d5ff,
   'green': #ffb3c9,
   'blue': #ff9ebb,
   'pink': #75e3ff,
   'yellow': #75e3ff,
   'orange': #bdf1ff,
   'red': #75e3ff,
-  'purple': #75e3ff,
+  'purple': #75e3ff
 );
 
 $border-width: 4;
@@ -999,7 +979,8 @@ $border-width-px: $border-width * 1px;
 
 .major_announcement_title {
   font-size: 175%;
-  padding: 0rem 0.5rem;
+  // EffigyEdit Change
+  padding: 0rem 0.4rem;
   line-height: 100%;
   text-align: left;
   text-decoration: none;
@@ -1008,8 +989,8 @@ $border-width-px: $border-width * 1px;
 
 .subheader_announcement_text {
   font-weight: bold;
-  padding: 0 0.5rem;
-  padding-top: 0.25rem;
+  // EffigyEdit Change
+  padding: 0.25rem 0 0 0.5rem;
   line-height: 100%;
   width: 100%;
   height: 100%;
@@ -1019,7 +1000,8 @@ $border-width-px: $border-width * 1px;
 
 .major_announcement_text {
   color: #eaeaea;
-  background-color: #131313;
+  // EffigyEdit Change
+  // background-color: #131313;
   font-weight: bold;
   font-size: 100%;
   text-align: left;
@@ -1030,7 +1012,8 @@ $border-width-px: $border-width * 1px;
 
 .minor_announcement_title {
   font-weight: bold;
-  padding: 0 0.5rem;
+  // EffigyEdit Change
+  padding: 0 0.4rem;
   padding-top: 0;
   line-height: 100%;
   width: 100%;
@@ -1040,8 +1023,9 @@ $border-width-px: $border-width * 1px;
 }
 
 .minor_announcement_text {
-  background-color: #202020;
   color: #eaeaea;
+  // EffigyEdit Change - Custom CSS
+  // background-color: #202020;
   padding: 0.5rem 0.5rem;
   text-align: left;
   font-size: 100%;
@@ -1056,11 +1040,11 @@ $border-width-px: $border-width * 1px;
 @each $color-name, $color-value in $alert-stripe-colors {
   .chat_alert_#{$color-name} {
     color: #ffffff;
-    padding: 0.5rem 0.5rem;
     box-shadow: none;
     font-weight: bold;
     margin: 1rem 0 1rem 0;
-    padding: 0;
+    // EffigyEdit Change - Custom CSS
+    padding: 0.25rem 0.25rem 0.25rem 0.25rem;
     display: flex;
     flex-direction: column;
     border-image: repeating-linear-gradient(
@@ -1089,7 +1073,7 @@ $border-width-px: $border-width * 1px;
   .chat_alert_#{$color-name} .subheader_announcement_text {
     color: map.get($alert-subheader-header-colors, $color-name);
   }
-
+  /* // EffigyEdit Remove - Custom CSS
   .chat_alert_#{$color-name} .minor_announcement_text {
     background-color: darken(map.get($alert-stripe-colors, $color-name), 5);
   }
@@ -1097,4 +1081,5 @@ $border-width-px: $border-width * 1px;
   .chat_alert_#{$color-name} .major_announcement_text {
     background-color: darken(map.get($alert-stripe-colors, $color-name), 5);
   }
+  */ // EffigyEdit Remove End
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -954,23 +954,23 @@ $alert-major-header-colors: (
   'default': #ff4791,
   'green': #00ff80,
   'blue': #33d5ff,
-  'pink': #ff80b3,
+  'pink': #ff4791,
   'yellow': #fff4e0,
   'orange': #feefe7,
-  'red': #ffa8c4,
+  'red': #ff4791,
   'purple': #c7a1f7
 );
 
 $alert-subheader-header-colors: (
   // EffigyEdit Change
   'default': #33d5ff,
-  'green': #ffb3c9,
-  'blue': #ff9ebb,
-  'pink': #75e3ff,
-  'yellow': #75e3ff,
-  'orange': #bdf1ff,
-  'red': #75e3ff,
-  'purple': #75e3ff
+  'green': #ff85b5,
+  'blue': #ff4791,
+  'pink': #33d5ff,
+  'yellow': #33d5ff,
+  'orange': #33d5ff,
+  'red': #33d5ff,
+  'purple': #33d5ff
 );
 
 $border-width: 4;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -977,222 +977,6 @@ h2.alert {
   border-bottom: 1px dashed #333;
 }
 
-// EffigyEdit Add -
-
-.efannouncemajtitle {
-  color: #ff0066;
-  text-decoration: underline;
-  font-weight: bold;
-  font-size: 175%;
-}
-
-.efannouncemajtext {
-  color: #202020;
-  font-weight: bold;
-  font-size: 125%;
-}
-
-.efannouncemintitle {
-  color: #007ee6;
-  font-weight: bold;
-  font-size: 150%;
-}
-
-.efannouncemintext {
-  color: #202020;
-  font-size: 125%;
-}
-
-.efchatalert {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #dedede;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #d1d1d1;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #dedede 10px,
-    #dedede 20px
-  );
-}
-
-.efchatalert_0 {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #c2ffcc;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #a8ffb7;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #c2ffcc 10px,
-    #c2ffcc 20px
-  );
-}
-
-.efchatalert_1 {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #b8e6ff;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #a8e1ff;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #b8e6ff 10px,
-    #b8e6ff 20px
-  );
-}
-
-.efchatalert_2 {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #bfbfbf;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #d4d4d4;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #bfbfbf 10px,
-    #bfbfbf 20px
-  );
-}
-
-.efchatalert_3 {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #ffc2f4;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #ffb3f3;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #ffc2f4 10px,
-    #ffc2f4 20px
-  );
-}
-
-.efchatalert_4 {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #ffe880;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #fff0ad;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #ffe880 10px,
-    #ffe880 20px
-  );
-}
-
-.efchatalert_5 {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #ffbb99;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #ffc9ad;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #ffbb99 10px,
-    #ffbb99 20px
-  );
-}
-
-.efchatalert_6 {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #ff99aa;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #ffadbb;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #ff99aa 10px,
-    #ff99aa 20px
-  );
-}
-
-.efchatalert_7 {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #d7c2ff;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #ccb3ff;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #d7c2ff 10px,
-    #d7c2ff 20px
-  );
-}
-
-.minorannounce {
-  color: #202020;
-  padding: 0.5em 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: none;
-  font-weight: bold;
-  border: 1px solid #dedede;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0.5em 0.75em;
-  background-color: #d1d1d1;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 10px,
-    #dedede 10px,
-    #dedede 20px
-  );
-}
-
 .looc {
   color: #b300b0;
 }
@@ -1201,47 +985,51 @@ h2.alert {
 }
 
 $alert-stripe-colors: (
-  'default': #b3bfff,
+  // EffigyEdit Change
+  'default': #e3e3e3,
   'green': #adffad,
   'blue': #b3bfff,
   'pink': #ffb3df,
   'yellow': #fff3b3,
   'orange': #ffe2b3,
   'red': #ffb3b3,
-  'purple': #fac2ff,
+  'purple': #fac2ff
 );
 
 $alert-stripe-alternate-colors: (
-  'default': #bdc8ff,
+  // EffigyEdit Change
+  'default': #ebebeb,
   'green': #bdffbd,
   'blue': #bdc8ff,
   'pink': #ffc2e5,
   'yellow': #fff5c2,
   'orange': #ffe8c2,
   'red': #ffc2c2,
-  'purple': #fbd1ff,
+  'purple': #fbd1ff
 );
 
 $alert-major-header-colors: (
-  'default': #003061,
+  // EffigyEdit Change
+  'default': #eb005e,
   'green': #005229,
   'blue': #003061,
   'pink': #800033,
   'yellow': #754900,
   'orange': #823208,
   'red': #800029,
-  'purple': #450d8c,
+  'purple': #450d8c
 );
 
 $alert-subheader-header-colors: (
-  'default': #6b0020,
+  // EffigyEdit Change
+  'default': #002c85,
   'green': #6b0020,
   'blue': #6b0020,
   'pink': #002c85,
   'yellow': #002c85,
   'orange': #002c85,
   'red': #002c85,
-  'purple': #002c85,
+  'purple': #002c85
 );
 
 $border-width: 4;
@@ -1250,7 +1038,8 @@ $border-width-px: $border-width * 1px;
 
 .major_announcement_title {
   font-size: 175%;
-  padding: 0rem 0.5rem;
+  // EffigyEdit Change
+  padding: 0rem 0.4rem;
   line-height: 100%;
   text-align: left;
   text-decoration: none;
@@ -1259,8 +1048,8 @@ $border-width-px: $border-width * 1px;
 
 .subheader_announcement_text {
   font-weight: bold;
-  padding: 0 0.5rem;
-  padding-top: 0.25rem;
+  // EffigyEdit Change
+  padding: 0.25rem 0 0 0.5rem;
   line-height: 100%;
   width: 100%;
   height: 100%;
@@ -1270,7 +1059,8 @@ $border-width-px: $border-width * 1px;
 
 .major_announcement_text {
   color: #131313;
-  background-color: #eaeaea;
+  // EffigyEdit Change
+  // background-color: #eaeaea;
   font-weight: bold;
   font-size: 100%;
   text-align: left;
@@ -1281,7 +1071,8 @@ $border-width-px: $border-width * 1px;
 
 .minor_announcement_title {
   font-weight: bold;
-  padding: 0 0.5rem;
+  // EffigyEdit Change
+  padding: 0 0.4rem;
   padding-top: 0;
   line-height: 100%;
   width: 100%;
@@ -1291,7 +1082,8 @@ $border-width-px: $border-width * 1px;
 }
 
 .minor_announcement_text {
-  background-color: #eaeaea;
+  // EffigyEdit Change - Custom CSS
+  // background-color: #eaeaea;
   color: #202020;
   padding: 0.5rem 0.5rem;
   text-align: left;
@@ -1311,7 +1103,8 @@ $border-width-px: $border-width * 1px;
     box-shadow: none;
     font-weight: bold;
     margin: 1rem 0 1rem 0;
-    padding: 0;
+    // EffigyEdit Change - Custom CSS
+    padding: 0.25rem 0.25rem 0.25rem 0.25rem;
     display: flex;
     flex-direction: column;
     border-image: repeating-linear-gradient(
@@ -1340,7 +1133,7 @@ $border-width-px: $border-width * 1px;
   .chat_alert_#{$color-name} .subheader_announcement_text {
     color: map.get($alert-subheader-header-colors, $color-name);
   }
-
+  /* // EffigyEdit Remove - Custom CSS
   .chat_alert_#{$color-name} .minor_announcement_text {
     background-color: lighten(
       map.get($alert-stripe-alternate-colors, $color-name),
@@ -1354,4 +1147,5 @@ $border-width-px: $border-width * 1px;
       5
     );
   }
+  */ // EffigyEdit Remove End
 }


### PR DESCRIPTION
## About The Pull Request

- Adjusts the announcement padding/margins for our custom fonts.
- Sets default announcement color back to grey.
- Color matches TG https://github.com/tgstation/tgstation/pull/79315 for the most part
- Removes old Effigy specific CSS that's now included upstream

:cl: LT3
image: Announcement tweaks using new CSS
/:cl: