### PR TITLE
Update player prefs menu options

### DIFF
--- a/local/code/modules/client/preferences/erp_preferences.dm
+++ b/local/code/modules/client/preferences/erp_preferences.dm
@@ -131,7 +131,7 @@
 	return list("Yes - Switch", "Yes - Sub", "Yes - Dom", "Check OOC", "Ask", "No", "Yes")
 
 /datum/preference/choiced/erp_status/create_default_value()
-	return "Ask"
+	return "No"
 
 /datum/preference/choiced/erp_status/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))
@@ -150,66 +150,6 @@
 	. = ..()
 
 /datum/preference/choiced/erp_status/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
-	return FALSE
-
-/datum/preference/choiced/erp_status_nc
-	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
-	savefile_identifier = PREFERENCE_CHARACTER
-	savefile_key = "erp_status_pref_nc"
-
-/datum/preference/choiced/erp_status_nc/init_possible_values()
-	return list("Yes - Switch", "Yes - Sub", "Yes - Dom", "Check OOC", "Ask", "No", "Yes")
-
-/datum/preference/choiced/erp_status_nc/create_default_value()
-	return "Ask"
-
-/datum/preference/choiced/erp_status_nc/is_accessible(datum/preferences/preferences)
-	if (!..(preferences))
-		return FALSE
-
-	if(CONFIG_GET(flag/disable_erp_preferences))
-		return FALSE
-
-	return preferences.read_preference(/datum/preference/toggle/master_erp_preferences)
-
-/datum/preference/choiced/erp_status_nc/deserialize(input, datum/preferences/preferences)
-	if(CONFIG_GET(flag/disable_erp_preferences))
-		return "No"
-	if(!preferences.read_preference(/datum/preference/toggle/master_erp_preferences))
-		return "No"
-	. = ..()
-
-/datum/preference/choiced/erp_status_nc/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
-	return FALSE
-
-/datum/preference/choiced/erp_status_v
-	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
-	savefile_identifier = PREFERENCE_CHARACTER
-	savefile_key = "erp_status_pref_v"
-
-/datum/preference/choiced/erp_status_v/init_possible_values()
-	return list("Yes - Switch", "Yes - Prey", "Yes - Pred", "Check OOC", "Ask", "No", "Yes")
-
-/datum/preference/choiced/erp_status_v/create_default_value()
-	return "Ask"
-
-/datum/preference/choiced/erp_status_v/is_accessible(datum/preferences/preferences)
-	if (!..(preferences))
-		return FALSE
-
-	if(CONFIG_GET(flag/disable_erp_preferences))
-		return FALSE
-
-	return preferences.read_preference(/datum/preference/toggle/master_erp_preferences)
-
-/datum/preference/choiced/erp_status_v/deserialize(input, datum/preferences/preferences)
-	if(CONFIG_GET(flag/disable_erp_preferences))
-		return "No"
-	if(!preferences.read_preference(/datum/preference/toggle/master_erp_preferences))
-		return "No"
-	. = ..()
-
-/datum/preference/choiced/erp_status_v/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return FALSE
 
 /datum/preference/choiced/erp_status_mechanics

--- a/local/code/modules/mob/living/examine_tgui.dm
+++ b/local/code/modules/mob/living/examine_tgui.dm
@@ -59,12 +59,8 @@
 	//  Handle OOC notes first
 	if(preferences && preferences.read_preference(/datum/preference/toggle/master_erp_preferences))
 		var/e_prefs = preferences.read_preference(/datum/preference/choiced/erp_status)
-		var/e_prefs_nc = preferences.read_preference(/datum/preference/choiced/erp_status_nc)
-		var/e_prefs_v = preferences.read_preference(/datum/preference/choiced/erp_status_v)
 		var/e_prefs_mechanical = preferences.read_preference(/datum/preference/choiced/erp_status_mechanics)
 		ooc_notes += "ERP: [e_prefs]\n"
-		ooc_notes += "Non-Con: [e_prefs_nc]\n"
-		ooc_notes += "Vore: [e_prefs_v]\n"
 		ooc_notes += "ERP Mechanics: [e_prefs_mechanical]\n"
 		ooc_notes += "\n"
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/genitals.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/genitals.tsx
@@ -155,17 +155,7 @@ export const erp_status_pref: FeatureChoiced = {
   component: FeatureDropdownInput,
 };
 
-export const erp_status_pref_nc: FeatureChoiced = {
-  name: 'ERP Non-Con Status',
-  component: FeatureDropdownInput,
-};
-
-export const erp_status_pref_v: FeatureChoiced = {
-  name: 'ERP Vore Status',
-  component: FeatureDropdownInput,
-};
-
 export const erp_status_pref_mechanics: FeatureChoiced = {
-  name: 'ERP Mechanical Status',
+  name: 'ERP Status (Mechanical)',
   component: FeatureDropdownInput,
 };


### PR DESCRIPTION
## About The Pull Request

- Removes NC and vore preferences from character prefs
- Put 'mechanical' in brackets to appear after ERP Status
- Set ERP Status default value to 'No'

We don't allow NC and vore isn't in the codebase, simplifying this to a single prefs box for players. ERP pref should default to No because it's entirely opt-in.

## Changelog

:cl: LT3
del: Removed NC and vore preference options
code: ERP Status now defaults to No instead of Ask
/:cl: