### PR TITLE
More /local/ Parity

### DIFF
--- a/code/__DEFINES/_effigy/loadouts.dm
+++ b/code/__DEFINES/_effigy/loadouts.dm
@@ -76,6 +76,7 @@
 
 #define INFO_GREYSCALE "greyscale"
 #define INFO_NAMED "name"
+#define INFO_DESCRIBED "description"
 
 /// Max amonut of misc / backpack items that are allowed.
 #define MAX_ALLOWED_MISC_ITEMS 3

--- a/local/code/datums/loadout_manager.dm
+++ b/local/code/datums/loadout_manager.dm
@@ -207,10 +207,14 @@
 /// Set [item]'s name to input provided.
 /datum/loadout_manager/proc/set_item_name(datum/loadout_item/item)
 	var/current_name = ""
+	var/current_desc = ""
 	if(INFO_NAMED in owner.prefs.loadout_list[item.item_path])
 		current_name = owner.prefs.loadout_list[item.item_path][INFO_NAMED]
+	if(INFO_DESCRIBED in owner.prefs.loadout_list[item.item_path])
+		current_desc = owner.prefs.loadout_list[item.item_path][INFO_DESCRIBED]
 
-	var/input_name = stripped_input(owner, "What name do you want to give [item.name]? Leave blank to clear.", "[item.name] name", current_name, MAX_NAME_LEN)
+	var/input_name = tgui_input_text(owner, "What name do you want to give [item.name]? Leave blank to clear.", "[item.name] name", current_name, MAX_NAME_LEN)
+	var/input_desc = tgui_input_text(owner, "What description do you want to give [item.name]? 256 character max, leave blank to clear.", "[item.name] description", current_desc, 256, multiline = TRUE)
 	if(QDELETED(src) || QDELETED(owner) || QDELETED(owner.prefs))
 		return
 
@@ -223,6 +227,11 @@
 	else
 		if(INFO_NAMED in owner.prefs.loadout_list[item.item_path])
 			owner.prefs.loadout_list[item.item_path] -= INFO_NAMED
+	if(input_desc)
+		owner.prefs.loadout_list[item.item_path][INFO_DESCRIBED] = input_desc
+	else
+		if(INFO_DESCRIBED in owner.prefs.loadout_list[item.item_path])
+			owner.prefs.loadout_list[item.item_path] -= INFO_DESCRIBED
 
 /datum/loadout_manager/proc/display_job_restrictions(datum/loadout_item/item)
 	var/composed_message = span_boldnotice("The [initial(item.item_path.name)] is restricted to the following roles: <br>")

--- a/local/code/datums/loadouts/_loadout_datum.dm
+++ b/local/code/datums/loadouts/_loadout_datum.dm
@@ -117,8 +117,10 @@ GLOBAL_LIST_EMPTY(all_loadout_datums)
 		if(equipped_item)
 			if(INFO_NAMED in our_loadout[item_path])
 				equipped_item.name = our_loadout[item_path][INFO_NAMED]
+				equipped_item.on_loadout_custom_named()
 			if(INFO_DESCRIBED in our_loadout[item_path])
 				equipped_item.desc = our_loadout[item_path][INFO_DESCRIBED]
+				equipped_item.on_loadout_custom_described()
 		else
 			stack_trace("[type] on_equip_item(): Could not locate item (path: [item_path]) in [equipper]'s contents to set name/desc!")
 

--- a/local/code/datums/loadouts/_loadout_datum.dm
+++ b/local/code/datums/loadouts/_loadout_datum.dm
@@ -38,8 +38,8 @@ GLOBAL_LIST_EMPTY(all_loadout_datums)
 /datum/loadout_item
 	/// Displayed name of the loadout item.
 	var/name
-	/// Whether this item can be renamed.
-	var/can_be_named = FALSE
+	/// Whether this item can be renamed and described.
+	var/can_be_named = TRUE
 	/// The category of the loadout item.
 	var/category
 	/// The actual item path of the loadout item.
@@ -112,12 +112,15 @@ GLOBAL_LIST_EMPTY(all_loadout_datums)
 			else
 				stack_trace("[type] on_equip_item(): Could not locate backpack item (path: [item_path]) in [equipper]'s contents to set greyscaling!")
 
-	if(can_be_named && !visuals_only && (INFO_NAMED in our_loadout[item_path]))
+	if(can_be_named && !visuals_only)
 		var/obj/item/equipped_item = locate(item_path) in equipper.get_all_gear()
 		if(equipped_item)
-			equipped_item.name = our_loadout[item_path][INFO_NAMED]
+			if(INFO_NAMED in our_loadout[item_path])
+				equipped_item.name = our_loadout[item_path][INFO_NAMED]
+			if(INFO_DESCRIBED in our_loadout[item_path])
+				equipped_item.desc = our_loadout[item_path][INFO_DESCRIBED]
 		else
-			stack_trace("[type] on_equip_item(): Could not locate item (path: [item_path]) in [equipper]'s contents to set name!")
+			stack_trace("[type] on_equip_item(): Could not locate item (path: [item_path]) in [equipper]'s contents to set name/desc!")
 
 /*
  * Called after the item is equipped on [equipper], at the end of character setup.

--- a/local/code/datums/loadouts/loadout_datum_pocket.dm
+++ b/local/code/datums/loadouts/loadout_datum_pocket.dm
@@ -161,3 +161,11 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 /datum/loadout_item/pocket_items/newspaper
 	name = "Newspaper"
 	item_path = /obj/item/newspaper
+
+/datum/loadout_item/pocket_items/clipboard
+	name = "Clipboard"
+	item_path = /obj/item/clipboard
+
+/datum/loadout_item/pocket_items/folder
+	name = "Folder"
+	item_path = /obj/item/folder

--- a/local/code/datums/loadouts/loadout_datum_toys.dm
+++ b/local/code/datums/loadouts/loadout_datum_toys.dm
@@ -2,7 +2,6 @@ GLOBAL_LIST_INIT(loadout_toys, generate_loadout_items(/datum/loadout_item/toys))
 
 /datum/loadout_item/toys
 	category = LOADOUT_ITEM_TOYS
-	can_be_named = TRUE
 
 /*
 *	PLUSHIES

--- a/local/code/game/atoms.dm
+++ b/local/code/game/atoms.dm
@@ -1,0 +1,7 @@
+/// Called after a loadout item gets custom named
+/atom/proc/on_loadout_custom_named()
+	return
+
+/// Called after a loadout item gets a custom description
+/atom/proc/on_loadout_custom_described()
+	return

--- a/local/code/game/objects/items/plushes.dm
+++ b/local/code/game/objects/items/plushes.dm
@@ -1,3 +1,7 @@
+// Because plushes have a second desc var that needs to be updated
+/obj/item/toy/plush/on_loadout_custom_described()
+	normal_desc = desc
+
 /obj/item/toy/plush/effigy
 	icon = 'local/icons/obj/toys/plushes.dmi'
 	inhand_icon_state = null

--- a/local/code/modules/client/loadout_outfit_helpers.dm
+++ b/local/code/modules/client/loadout_outfit_helpers.dm
@@ -69,6 +69,8 @@
 		equipOutfit(equipped_outfit, visuals_only)
 
 	for(var/datum/loadout_item/item as anything in loadout_datums)
+		if(item.restricted_roles && equipping_job && !(equipping_job.title in item.restricted_roles))
+			continue
 		item.on_equip_item(preference_source, src, visuals_only)
 
 	regenerate_icons()

--- a/local/code/modules/clothing/clothing_variation_overrides/suit.dm
+++ b/local/code/modules/clothing/clothing_variation_overrides/suit.dm
@@ -120,6 +120,7 @@
 
 /obj/item/clothing/suit/hooded/wintercoat
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+	gets_cropped_on_taurs = FALSE
 
 /obj/item/clothing/suit/toggle/cargo_tech
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON

--- a/local/code/modules/clothing/under/jobs/medical.dm
+++ b/local/code/modules/clothing/under/jobs/medical.dm
@@ -66,6 +66,10 @@
 	dying_key = DYE_REGISTRY_JUMPSKIRT
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+	gets_cropped_on_taurs = FALSE
+
+/obj/item/clothing/under/rank/medical/chemist/skirt
+	gets_cropped_on_taurs = FALSE
 
 /*
 *	PARAMEDIC

--- a/local/code/modules/modular_implants/soulcatcher/soulcatcher_tgui.dm
+++ b/local/code/modules/modular_implants/soulcatcher/soulcatcher_tgui.dm
@@ -126,7 +126,7 @@
 			return TRUE
 
 		if("modify_name")
-			var/new_name = tgui_input_text(usr,"Choose a new name to send messages as", name, target_room.room_description, multiline = TRUE)
+			var/new_name = tgui_input_text(usr,"Choose a new name to send messages as", name, target_room.outside_voice, multiline = TRUE)
 			if(!new_name)
 				return FALSE
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6135,6 +6135,7 @@
 #include "local\code\datums\station_traits\neutral_traits.dm"
 #include "local\code\datums\votes\_vote_datum.dm"
 #include "local\code\datums\wounds\slash.dm"
+#include "local\code\game\atoms.dm"
 #include "local\code\game\atoms_movable.dm"
 #include "local\code\game\area\alert_sound_to_playing.dm"
 #include "local\code\game\area\areas\mining.dm"


### PR DESCRIPTION
:cl: Iamgoofball, sqnztb, honkpocket, vinylspiders, Plum-but-gayer for Skyrat 13
qol: You can now rename and describe any loadout item, not just plushies.
fix: soulcatchers' edit name button correctly displays the host name
fix: Fixes more unintended taur clothing cropping.
fix: fixed a bug where loadout plushes would sometimes have their custom descriptions reset under certain conditions
fix: fixes some of the runtimes in the loadout system caused by job/species restricted items
add: Bureaucrats rejoice! Clipboards and folders are now available in the loadout menu, under the 'Other' tab.
/:cl:
