### PR TITLE
Remove labcoats override

### DIFF
--- a/local/code/datums/loadouts/loadout_datum_suit.dm
+++ b/local/code/datums/loadouts/loadout_datum_suit.dm
@@ -587,7 +587,7 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 // LABCOATS
 /datum/loadout_item/suit/labcoat_highvis
 	name = "High-Vis Labcoat"
-	item_path = /obj/item/clothing/suit/toggle/labcoat/skyrat/highvis
+	item_path = /obj/item/clothing/suit/toggle/labcoat/effigy/highvis
 	restricted_roles = list(JOB_CHIEF_MEDICAL_OFFICER, JOB_MEDICAL_DOCTOR, JOB_PARAMEDIC, JOB_CHEMIST, JOB_STATION_ENGINEER, JOB_ATMOSPHERIC_TECHNICIAN, JOB_CHIEF_ENGINEER, JOB_CHEMIST)
 
 /*

--- a/local/code/game/objects/effects/spawners/random/clothing.dm
+++ b/local/code/game/objects/effects/spawners/random/clothing.dm
@@ -51,7 +51,7 @@
 		/obj/item/clothing/suit/armor/vest/warden/syndicate, // Interdyne/DS-2 Leftover
 		/obj/item/clothing/suit/toggle/hop_parade,
 		/obj/item/clothing/suit/armor/vest/capcarapace/jacket,
-		/obj/item/clothing/suit/toggle/labcoat/skyrat/rd,
+		/obj/item/clothing/suit/toggle/labcoat/effigy/rd,
 		/obj/item/clothing/suit/kimjacket,
 		/obj/item/clothing/suit/brownfurrich,
 		/obj/item/clothing/suit/brownfurrich/public,

--- a/local/code/modules/clothing/clothing_variation_overrides/suit.dm
+++ b/local/code/modules/clothing/clothing_variation_overrides/suit.dm
@@ -19,7 +19,7 @@
 /obj/item/clothing/suit/toggle/suspenders
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
-/obj/item/clothing/suit/toggle/labcoat/paramedic
+/obj/item/clothing/suit/toggle/labcoat
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
 /obj/item/clothing/suit/jacket/miljacket

--- a/local/code/modules/clothing/suits/labcoat.dm
+++ b/local/code/modules/clothing/suits/labcoat.dm
@@ -1,11 +1,11 @@
-/obj/item/clothing/suit/toggle/labcoat/skyrat
-	name = "SR LABCOAT SUIT DEBUG"
-	desc = "REPORT THIS IF FOUND"
+/obj/item/clothing/suit/toggle/labcoat/effigy
+	name = "debug labcoat"
+	desc = "someone screwed up"
 	icon = 'local/icons/obj/clothing/suits/labcoat.dmi'
 	worn_icon = 'local/icons/mob/clothing/suits/labcoat.dmi'
 	icon_state = null //Keeps this from showing up under the chameleon hat
 
-/obj/item/clothing/suit/toggle/labcoat/skyrat/rd
+/obj/item/clothing/suit/toggle/labcoat/effigy/rd
 	name = "research directors labcoat"
 	desc = "A Nanotrasen standard labcoat for certified Research Directors. It has an extra plastic-latex lining on the outside for more protection from chemical and viral hazards."
 	icon_state = "labcoat_rd"
@@ -18,19 +18,19 @@
 	fire = 80
 	acid = 70
 
-/obj/item/clothing/suit/toggle/labcoat/skyrat/highvis
+/obj/item/clothing/suit/toggle/labcoat/effigy/highvis
 	name = "high vis labcoat"
 	desc = "A high visibility vest for emergency responders, intended to draw attention away from the blood."
 	icon_state = "labcoat_highvis"
 	blood_overlay_type = "armor"
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
-/obj/item/clothing/suit/toggle/labcoat/skyrat/highvis/worn_overlays(mutable_appearance/standing, isinhands, icon_file)
+/obj/item/clothing/suit/toggle/labcoat/effigy/highvis/worn_overlays(mutable_appearance/standing, isinhands, icon_file)
 	. = ..()
 	if(!isinhands)
 		. += emissive_appearance(icon_file, "[icon_state]-emissive", src, alpha = src.alpha)
 
-/obj/item/clothing/suit/toggle/labcoat/skyrat/hospitalgown //Intended to keep patients modest while still allowing for surgeries
+/obj/item/clothing/suit/toggle/labcoat/effigy/hospitalgown //Intended to keep patients modest while still allowing for surgeries
 	name = "hospital gown"
 	desc = "A complicated drapery with an assortment of velcros and strings, designed to keep a patient modest during medical stay and surgeries."
 	icon_state = "hgown"

--- a/local/code/modules/mob/dead/new_player/sprite_accessories/genitals.dm
+++ b/local/code/modules/mob/dead/new_player/sprite_accessories/genitals.dm
@@ -22,7 +22,7 @@
 			if((target_mob.w_uniform && target_mob.w_uniform.body_parts_covered & genital_location) || (target_mob.wear_suit && target_mob.wear_suit.body_parts_covered & genital_location))
 				return TRUE
 			//Do they have a Hospital Gown covering them? (The gown has no body_parts_covered so needs its own check)
-			if(istype(target_mob.wear_suit, /obj/item/clothing/suit/toggle/labcoat/skyrat/hospitalgown))
+			if(istype(target_mob.wear_suit, /obj/item/clothing/suit/toggle/labcoat/effigy/hospitalgown))
 				return TRUE
 
 			//Are they wearing an Undershirt?

--- a/local/code/modules/vending/wardrobes.dm
+++ b/local/code/modules/vending/wardrobes.dm
@@ -2,13 +2,13 @@
 	effigy_products = list(
 		/obj/item/radio/headset/headset_med = 3,
 		/obj/item/clothing/gloves/latex/nitrile = 2,
-		/obj/item/clothing/suit/toggle/labcoat/skyrat/hospitalgown = 5,
+		/obj/item/clothing/suit/toggle/labcoat/effigy/hospitalgown = 5,
 		/obj/item/storage/belt/medbandolier = 2,
 		/obj/item/clothing/under/rank/engineering/engineer/skyrat/hazard_chem/emt = 2,
 		/obj/item/clothing/under/rank/medical/scrubs/skyrat/red = 4,
 		/obj/item/clothing/under/rank/medical/scrubs/skyrat/white = 4,
 		/obj/item/clothing/under/rank/medical/doctor/skyrat/utility = 4,
-		/obj/item/clothing/suit/toggle/labcoat/skyrat/highvis = 2,
+		/obj/item/clothing/suit/toggle/labcoat/effigy/highvis = 2,
 	)
 
 /obj/machinery/vending/wardrobe/engi_wardrobe
@@ -24,14 +24,14 @@
 		/obj/item/clothing/head/utility/hardhat/dblue = 2,
 		/obj/item/clothing/head/utility/hardhat/welding/dblue = 2,
 		/obj/item/clothing/head/utility/hardhat/red = 2,
-		/obj/item/clothing/suit/toggle/labcoat/skyrat/highvis = 2,
+		/obj/item/clothing/suit/toggle/labcoat/effigy/highvis = 2,
 	)
 
 /obj/machinery/vending/wardrobe/atmos_wardrobe
 	effigy_products = list(
 		/obj/item/clothing/glasses/meson/engine = 2,
 		/obj/item/clothing/head/beret/atmos = 4,
-		/obj/item/clothing/suit/toggle/labcoat/skyrat/highvis = 2,
+		/obj/item/clothing/suit/toggle/labcoat/effigy/highvis = 2,
 	)
 
 /obj/machinery/vending/wardrobe/cargo_wardrobe
@@ -101,7 +101,7 @@
 		/obj/item/clothing/under/rank/medical/chemist/skyrat/formal = 2,
 		/obj/item/clothing/under/rank/medical/chemist/skyrat/formal/skirt = 2,
 		/obj/item/clothing/head/beret/medical/chemist = 2,
-		/obj/item/clothing/suit/toggle/labcoat/skyrat/highvis = 2,
+		/obj/item/clothing/suit/toggle/labcoat/effigy/highvis = 2,
 	)
 
 /obj/machinery/vending/wardrobe/viro_wardrobe


### PR DESCRIPTION
## About The Pull Request

Removes labcoat override for digi sprite until it can be converted to GAGS.

## Changelog

:cl: LT3
fix: Labcoats should no longer be a counterstrike texture
/:cl: