### PR TITLE
Increase TGUI timeout tolerance

### DIFF
--- a/tgui/packages/tgui-panel/game/constants.ts
+++ b/tgui/packages/tgui-panel/game/constants.ts
@@ -4,4 +4,4 @@
  * @license MIT
  */
 
-export const CONNECTION_LOST_AFTER = 20000;
+export const CONNECTION_LOST_AFTER = 35000; // EffigyEdit Change - Original: 20000


### PR DESCRIPTION
## About The Pull Request

Increases the TGUI reconnect threshold

## Why It's Good For The Game

The server takes more than 20 seconds to reboot, so this will make the auto reconnect on round restart more consistent.

## Changelog

:cl: LT3
config: TGUI reconnect threshold time increased
/:cl: