### PR TITLE
Fixes features not updating when changing character slots

### DIFF
--- a/local/code/modules/mob/living/human/species.dm
+++ b/local/code/modules/mob/living/human/species.dm
@@ -16,6 +16,7 @@
 		if ( \
 			(preference.relevant_mutant_bodypart in GLOB.default_mutant_bodyparts[name]) \
 			|| (preference.relevant_inherent_trait in inherent_traits) \
+			|| (preference.relevant_head_flag && check_head_flags(preference.relevant_head_flag)) \
 		)
 			features += preference.savefile_key
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
@@ -1,8 +1,8 @@
 import { sortBy, sortStrings } from 'common/collections';
 import { BooleanLike, classes } from 'common/react';
-import { ComponentType, createElement, ReactNode, useState } from 'react';
+import { ComponentType, createElement, ReactNode } from 'react';
 
-import { sendAct, useBackend } from '../../../../backend';
+import { sendAct, useBackend, useLocalState } from '../../../../backend';
 import {
   Box,
   Button,
@@ -389,7 +389,10 @@ export const FeatureValueInput = (props: {
 
   const feature = props.feature;
 
-  const [predictedValue, setPredictedValue] = useState(props.value);
+  const [predictedValue, setPredictedValue] = useLocalState(
+    `${props.featureId}_predictedValue_${data.active_slot}`,
+    props.value,
+  );
 
   const changeValue = (newValue: unknown) => {
     setPredictedValue(newValue);


### PR DESCRIPTION
## About The Pull Request

TG 81018

What it says on the tin. The entire bottom half of the prefs was not updating on switching character slots.

We need to use the old hook here because it needs the key to differentiate the active slot.

## Why It's Good For The Game

Bugfix for a kind of serious issue for downstreams, not so much here because there aren't really any text fields being used as features.

## Changelog

:cl: vinylspiders
fix: fixes features not updating when changing character slots
/:cl: