### PR TITLE
FoxHole + Rimpoint: Arcmining Patch, Cremator

### DIFF
--- a/_maps/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/map_files/FoxHoleStation/foxholestation.dmm
@@ -42931,6 +42931,8 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/east,
+/obj/item/boulder_beacon,
+/obj/structure/rack,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "xsP" = (

--- a/_maps/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/map_files/RimPoint/RimPoint.dmm
@@ -439,6 +439,15 @@
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
+"alf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/station/service/chapel)
 "alo" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
@@ -2104,6 +2113,16 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron,
 /area/station/security/office)
+"bbk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/misc/dirt/jungle,
+/area/taeloth)
 "bbm" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -2157,6 +2176,13 @@
 	},
 /turf/open/floor/plating/rust,
 /area/station/maintenance/department/crew_quarters/bar)
+"bcK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/chapel)
 "bcW" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
@@ -2280,6 +2306,16 @@
 	},
 /turf/open/misc/grass/jungle,
 /area/taeloth)
+"bfn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/service/chapel)
 "bfp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -2585,10 +2621,29 @@
 	},
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/commissary)
+"bkK" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/service/chapel/office)
 "bkN" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/workout)
+"bkO" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/service/chapel)
 "bkS" = (
 /obj/machinery/door/airlock/research/glass,
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
@@ -2832,6 +2887,8 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/item/boulder_beacon,
+/obj/structure/rack,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "bpG" = (
@@ -3380,10 +3437,8 @@
 /area/station/service/cafeteria)
 "bBZ" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/wood/parquet,
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "bCa" = (
 /obj/effect/turf_decal/siding/wideplating_new,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -5331,10 +5386,6 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
-"crX" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/service/chapel/office)
 "csi" = (
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 6
@@ -6122,7 +6173,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/parquet,
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "cHQ" = (
 /obj/effect/turf_decal/trimline/dark_blue/warning{
 	dir = 1
@@ -7243,10 +7294,6 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/science/xenobiology)
-"dkI" = (
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/glass,
-/area/station/service/chapel)
 "dkL" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -7321,7 +7368,7 @@
 "dlU" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "dma" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 8
@@ -8823,6 +8870,15 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/security/detectives_office)
+"dVi" = (
+/obj/structure/table/wood,
+/obj/item/camera_film{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/camera_film,
+/turf/open/floor/carpet/royalblack,
+/area/station/service/chapel/office)
 "dVC" = (
 /obj/effect/turf_decal/tile/blue/diagonal_edge,
 /obj/effect/turf_decal/tile/dark_blue/diagonal_centre,
@@ -9103,6 +9159,13 @@
 	},
 /turf/open/misc/beach/sand,
 /area/taeloth)
+"edQ" = (
+/obj/structure/hedge,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/chapel)
 "edX" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/bot_red/right,
@@ -12203,7 +12266,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured_large,
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "fqv" = (
 /obj/effect/turf_decal/trimline/yellow/line,
 /obj/structure/cable,
@@ -13710,6 +13773,18 @@
 	},
 /turf/open/floor/stone,
 /area/taeloth)
+"fYy" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/weather/dirt,
+/obj/machinery/door/airlock/maintenance/external,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/service/chapel)
 "fYA" = (
 /obj/structure/table,
 /obj/item/storage/box/condimentbottles{
@@ -14085,6 +14160,13 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
+"giE" = (
+/obj/structure/hedge,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/station/service/chapel/office)
 "giI" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -14153,6 +14235,16 @@
 	dir = 1
 	},
 /area/station/service/chapel)
+"gjZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/misc/dirt/jungle,
+/area/taeloth)
 "gkp" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/trimline/purple/line{
@@ -14381,6 +14473,12 @@
 "gor" = (
 /turf/open/openspace,
 /area/station/maintenance/department/security)
+"goC" = (
+/obj/machinery/airalarm/directional/north,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/iron/dark/herringbone,
+/area/station/service/chapel/office)
 "goJ" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -15015,6 +15113,13 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"gCM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 10
+	},
+/area/station/service/chapel)
 "gCO" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -15270,6 +15375,12 @@
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/command/heads_quarters/cmo)
+"gIH" = (
+/obj/structure/table/wood,
+/obj/item/storage/crayons,
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/carpet/royalblack,
+/area/station/service/chapel/office)
 "gIJ" = (
 /obj/effect/turf_decal/tile/dark_red/diagonal_edge,
 /obj/effect/landmark/start/security_officer,
@@ -15628,6 +15739,18 @@
 "gPC" = (
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"gQh" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/item/storage/fancy/candle_box{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/wood/large,
+/area/station/service/chapel)
 "gQk" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -15664,6 +15787,14 @@
 /obj/effect/landmark/navigate_destination/teleporter,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/teleporter)
+"gSo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 9
+	},
+/area/station/service/chapel)
 "gSv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -15899,11 +16030,11 @@
 /area/station/service/lawoffice)
 "gYi" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
 	},
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
@@ -16335,12 +16466,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/genetics)
-"hhK" = (
-/obj/machinery/door/airlock/mining,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/iron/textured_large,
-/area/station/cargo/miningoffice)
 "hig" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -16478,6 +16603,17 @@
 "hjC" = (
 /turf/open/floor/iron/freezer,
 /area/station/medical/chemistry)
+"hjF" = (
+/obj/structure/cable,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/service/chapel)
 "hjM" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 4
@@ -17664,6 +17800,22 @@
 "hNg" = (
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
+"hNp" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/item/food/grown/poppy{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/food/grown/poppy{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/food/grown/poppy,
+/turf/open/floor/wood/large,
+/area/station/service/chapel)
 "hNy" = (
 /obj/item/toy/cattoy,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -18372,6 +18524,15 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/bar/backroom)
+"iei" = (
+/obj/machinery/door/airlock/grunge,
+/obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/service/chapel/office)
 "ieM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -18744,6 +18905,10 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/atmos/storage/gas)
+"inU" = (
+/obj/item/pickaxe/improvised,
+/turf/open/misc/dirt/jungle,
+/area/taeloth)
 "iou" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
@@ -19644,13 +19809,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "iJa" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 8
-	},
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/floor/engine/hull/taeloth,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/taeloth)
 "iJl" = (
 /obj/structure/cable,
@@ -21169,6 +21338,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/office)
+"jsG" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/machinery/photocopier,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/station/service/chapel/office)
 "jsJ" = (
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 4
@@ -21347,6 +21525,12 @@
 /obj/structure/barricade/wooden,
 /turf/open/misc/dirt/jungle,
 /area/taeloth)
+"jvR" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark/side{
+	dir = 5
+	},
+/area/station/service/chapel)
 "jwo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -21504,6 +21688,13 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
+"jzV" = (
+/obj/machinery/vending/wardrobe/chap_wardrobe,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/station/service/chapel/office)
 "jzX" = (
 /obj/structure/railing/corner,
 /turf/open/openspace,
@@ -22030,6 +22221,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"jLs" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 6
+	},
+/area/station/service/chapel)
 "jLz" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
@@ -23179,6 +23376,17 @@
 	},
 /turf/open/floor/engine/hull/taeloth,
 /area/taeloth)
+"kie" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/checker{
+	dir = 1
+	},
+/area/station/service/chapel)
 "kir" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 9
@@ -23198,6 +23406,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
+"kiE" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/station/service/chapel)
 "kjk" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
@@ -23287,6 +23505,15 @@
 "klL" = (
 /turf/closed/wall/r_wall,
 /area/station/security/detectives_office)
+"klU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/iron/checker{
+	dir = 1
+	},
+/area/station/service/chapel)
 "klZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -23485,7 +23712,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/parquet,
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "kqS" = (
 /obj/item/stack/tile/wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -23612,6 +23839,11 @@
 /obj/effect/turf_decal/tile/dark_blue/diagonal_centre,
 /turf/open/floor/iron/diagonal,
 /area/station/security/prison)
+"ktP" = (
+/turf/open/floor/iron/dark/side{
+	dir = 9
+	},
+/area/station/service/chapel)
 "kuj" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/east,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/north,
@@ -26163,8 +26395,8 @@
 /area/station/cargo/storage)
 "lEb" = (
 /obj/machinery/door/window/right/directional/north{
-	req_access = list("ordnance");
-	name = "Ordnance Freezer Chamber Access"
+	req_access = list("chapel_office");
+	name = "Chapel Office"
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -26174,7 +26406,7 @@
 	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/wood/parquet,
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "lEV" = (
 /obj/effect/turf_decal/siding/wideplating_new/light{
 	dir = 5
@@ -26816,7 +27048,7 @@
 /obj/item/radio/intercom/chapel/directional/south,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark/textured,
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "lUX" = (
 /obj/effect/turf_decal/arrows/white,
 /turf/open/floor/iron/dark,
@@ -27191,6 +27423,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"mdJ" = (
+/obj/structure/table/wood,
+/obj/item/book/bible,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/service/chapel)
 "mdU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -27398,6 +27638,15 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/security/office)
+"mic" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/carpet/royalblack,
+/area/station/service/chapel/office)
 "mid" = (
 /obj/effect/turf_decal/trimline/purple/warning,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -28687,6 +28936,15 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/science/ordnance/testlab)
+"mJh" = (
+/obj/structure/bed/double{
+	dir = 1
+	},
+/obj/item/bedsheet/chaplain/double{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/service/chapel/office)
 "mJq" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -28713,10 +28971,10 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/command/teleporter)
 "mJJ" = (
-/obj/machinery/vending/wardrobe/chap_wardrobe,
 /obj/machinery/airalarm/directional/south,
+/obj/structure/rack,
 /turf/open/floor/wood/parquet,
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "mJR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -30831,7 +31089,6 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/chaplain,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
 	},
@@ -30839,7 +31096,7 @@
 	dir = 9
 	},
 /turf/open/floor/wood/parquet,
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "nIb" = (
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
@@ -31522,12 +31779,11 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
 "oan" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/wood/parquet,
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "oar" = (
 /obj/effect/turf_decal/siding/wideplating_new,
 /obj/structure/sign/departments/cargo/directional/east,
@@ -31601,6 +31857,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"ocN" = (
+/obj/machinery/button/crematorium{
+	id = "crematoriumChapel";
+	pixel_y = 24
+	},
+/obj/structure/chair/stool/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/station/service/chapel)
 "ode" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -31665,6 +31930,13 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/service/cafeteria)
+"oea" = (
+/obj/structure/bookcase,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/service/chapel)
 "oei" = (
 /obj/effect/turf_decal/siding/wideplating_new/terracotta{
 	dir = 4
@@ -31702,7 +31974,6 @@
 /obj/effect/turf_decal/siding/dark/end{
 	dir = 1
 	},
-/obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
@@ -32214,6 +32485,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/openspace,
 /area/taeloth)
+"osc" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/stairs/north,
+/turf/open/floor/plating,
+/area/station/service/chapel)
 "osp" = (
 /turf/open/water,
 /area/taeloth/underground)
@@ -33698,6 +33974,15 @@
 	},
 /turf/open/misc/dirt/jungle,
 /area/taeloth/underground)
+"oXN" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Crematorium"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/service/chapel)
 "oYl" = (
 /obj/structure/ladder,
 /obj/structure/railing,
@@ -34386,6 +34671,13 @@
 	},
 /turf/open/floor/stone,
 /area/taeloth)
+"ppe" = (
+/obj/effect/turf_decal/loading_area/red,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/station/service/chapel)
 "ppp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -35615,6 +35907,12 @@
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/closed/wall,
 /area/station/construction/mining/aux_base)
+"pRm" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 6
+	},
+/area/station/service/chapel)
 "pSe" = (
 /obj/machinery/light_switch/directional/south,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -35676,7 +35974,7 @@
 /obj/item/nullrod,
 /obj/item/soulstone/anybody/chaplain,
 /turf/open/floor/iron/dark/textured_large,
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "pTB" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -35918,7 +36216,6 @@
 /area/station/ai_monitored/command/storage/eva)
 "qaI" = (
 /obj/structure/altar_of_gods,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_half{
@@ -36275,6 +36572,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/science)
+"qhW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/checker{
+	dir = 1
+	},
+/area/station/service/chapel)
 "qik" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -36681,6 +36989,7 @@
 /area/taeloth)
 "qpY" = (
 /obj/machinery/light/directional/south,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
@@ -36823,6 +37132,14 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"qsu" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 6
+	},
+/area/station/service/chapel)
 "qsy" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -36836,6 +37153,13 @@
 "qsP" = (
 /turf/closed/wall,
 /area/station/commons/fitness/recreation)
+"qsW" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/floor/engine/hull/taeloth,
+/area/taeloth)
 "qtg" = (
 /obj/machinery/solarlight/camera_installed{
 	c_tag = "Exterior - Chemistry, East"
@@ -37039,6 +37363,15 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/small,
 /area/station/science)
+"qxi" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/wood/large,
+/area/station/service/chapel)
 "qxv" = (
 /obj/effect/turf_decal/siding/wideplating_new,
 /obj/structure/sign/departments/restroom/directional/north,
@@ -37711,6 +38044,10 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/checkpoint/engineering)
+"qLa" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
+/area/station/service/chapel)
 "qLp" = (
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 10
@@ -38388,6 +38725,9 @@
 	dir = 1
 	},
 /area/station/science/robotics)
+"qZT" = (
+/turf/open/openspace,
+/area/station/service/chapel)
 "rat" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /turf/open/floor/engine,
@@ -38456,6 +38796,22 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/misc/grass/jungle,
 /area/taeloth)
+"rdd" = (
+/obj/item/food/grown/harebell{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/food/grown/harebell{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/food/grown/harebell,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood/large,
+/area/station/service/chapel)
 "rdm" = (
 /obj/machinery/atmospherics/pipe/multiz/green/visible,
 /turf/open/floor/glass,
@@ -38574,6 +38930,17 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
+"rgB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/service/chapel)
 "rgM" = (
 /obj/effect/turf_decal/tile/dark_red/diagonal_edge,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -40369,6 +40736,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"rTF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/herringbone,
+/area/station/service/chapel/office)
 "rTM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -42090,6 +42463,10 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/commons/cryo)
+"sEg" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/glass,
+/area/station/service/chapel)
 "sEr" = (
 /obj/structure/chair,
 /obj/machinery/light/directional/north,
@@ -42392,6 +42769,18 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/radshelter/civil)
+"sLR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/service/chapel)
 "sMt" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -42854,6 +43243,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/blue,
 /area/station/medical/patients_rooms)
+"sXk" = (
+/turf/open/floor/iron/dark/side{
+	dir = 5
+	},
+/area/station/service/chapel)
 "sXI" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -44437,6 +44831,14 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/cmo)
+"tMZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/herringbone,
+/area/station/service/chapel/office)
 "tNc" = (
 /obj/effect/turf_decal/trimline/blue/corner,
 /obj/effect/turf_decal/siding/thinplating_new/light/corner,
@@ -44532,6 +44934,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
+"tPw" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/royalblack,
+/area/station/service/chapel/office)
 "tPW" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
@@ -45875,6 +46284,11 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/supermatter/room)
+"uqS" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/wood/large,
+/area/station/service/chapel/office)
 "uqV" = (
 /obj/effect/turf_decal/trimline/dark_red/warning{
 	dir = 1
@@ -46526,6 +46940,12 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/cargo/bitrunning/den)
+"uDE" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 10
+	},
+/area/station/service/chapel)
 "uDL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -46584,7 +47004,7 @@
 /obj/item/radio/intercom/chapel/directional/north,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/textured,
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "uFi" = (
 /obj/structure/weightmachine,
 /obj/effect/turf_decal/trimline/dark_red/warning,
@@ -46931,6 +47351,18 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/security/interrogation)
+"uOd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 5
+	},
+/area/station/service/chapel)
 "uOg" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -47003,6 +47435,12 @@
 	},
 /turf/open/floor/wood/large,
 /area/taeloth)
+"uPO" = (
+/obj/structure/bodycontainer/crematorium{
+	id = "crematoriumChapel"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/station/service/chapel)
 "uQv" = (
 /obj/structure/closet/secure_closet/security/science,
 /obj/effect/turf_decal/bot_red,
@@ -47409,6 +47847,12 @@
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/glass,
 /area/station/service/kitchen)
+"vbq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/herringbone,
+/area/station/service/chapel/office)
 "vbB" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /obj/effect/turf_decal/trimline/purple/end{
@@ -47820,6 +48264,25 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/glass,
 /area/station/hallway/secondary/recreation)
+"vjE" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/external,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/service/chapel)
 "vjS" = (
 /turf/closed/wall,
 /area/station/engineering/atmos/storage/gas)
@@ -48206,6 +48669,11 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/office)
+"vtC" = (
+/obj/machinery/light_switch/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/herringbone,
+/area/station/service/chapel/office)
 "vtN" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/siding/white{
@@ -48898,7 +49366,7 @@
 	name = "Confession Booth"
 	},
 /turf/open/floor/iron/dark/textured_large,
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "vJy" = (
 /obj/structure/chair/sofa/left/brown{
 	dir = 1
@@ -49825,6 +50293,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science)
+"wem" = (
+/obj/structure/dresser,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/service/chapel/office)
 "weK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -50166,8 +50641,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood/parquet,
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "wol" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -51068,6 +51544,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/recreation)
+"wIm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/misc/dirt/jungle,
+/area/taeloth)
 "wIL" = (
 /obj/machinery/air_sensor/plasma_tank,
 /turf/open/floor/engine/plasma,
@@ -51873,7 +52355,6 @@
 /turf/open/openspace,
 /area/station/command/bridge)
 "xbT" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_half{
@@ -53278,7 +53759,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured_large,
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "xDw" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -53461,6 +53942,19 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"xIB" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/taeloth)
 "xIJ" = (
 /turf/closed/wall/r_wall,
 /area/station/security/warden)
@@ -53830,11 +54324,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "xQg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -54172,6 +54665,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
+"xWr" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/wood/large,
+/area/station/service/chapel)
 "xWv" = (
 /obj/structure/railing/corner/end{
 	dir = 4
@@ -54706,6 +55207,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/studio)
+"yji" = (
+/turf/open/floor/iron/dark/side{
+	dir = 10
+	},
+/area/station/service/chapel)
 "yjA" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/fence/post{
@@ -95500,7 +96006,7 @@ aUQ
 tti
 tti
 tti
-hhK
+eog
 ydW
 eog
 vPT
@@ -102467,11 +102973,11 @@ eAL
 oLY
 oLY
 eAL
-dUB
-dUB
-dUB
+eAL
+eAL
+eAL
 vJu
-dUB
+eAL
 mLT
 pzM
 bVq
@@ -102724,11 +103230,11 @@ pKn
 izi
 izi
 qpY
-dUB
+eAL
 uFe
 dlU
 lUH
-dUB
+eAL
 vSj
 sAb
 sAb
@@ -102974,18 +103480,18 @@ acB
 acB
 acB
 acB
-xBp
+sEg
 omZ
 vRF
 guX
 aRe
 hlw
 bVL
-dUB
+eAL
 xCY
-dUB
-dUB
-dUB
+eAL
+eAL
+eAL
 sAb
 sAb
 msH
@@ -103228,8 +103734,8 @@ wKe
 wKe
 wKe
 wKe
-wKe
 eAL
+osc
 pcK
 xBp
 cBN
@@ -103241,7 +103747,7 @@ keT
 wnT
 oan
 bBZ
-dUB
+eAL
 sAb
 kSQ
 sAb
@@ -103485,9 +103991,9 @@ wKe
 wKe
 wKe
 wKe
-wKe
 eAL
-dkI
+osc
+xBp
 ofj
 gjy
 bIw
@@ -103498,7 +104004,7 @@ xbT
 xQd
 nHQ
 kqJ
-crX
+vWt
 sAb
 vSj
 vSj
@@ -103742,8 +104248,8 @@ wKe
 wKe
 wKe
 wKe
-wKe
 eAL
+osc
 xBp
 xBp
 omZ
@@ -103755,7 +104261,7 @@ keT
 lEb
 cHO
 mJJ
-dUB
+eAL
 uRT
 sAb
 ufD
@@ -103938,7 +104444,7 @@ ovD
 qvP
 vSj
 vSj
-vSj
+inU
 abe
 abe
 abe
@@ -103999,7 +104505,7 @@ wKe
 wKe
 wKe
 sAb
-sAb
+eAL
 eAL
 eAL
 amI
@@ -104009,10 +104515,10 @@ wJt
 rgT
 cdx
 keT
-dUB
+eAL
 fqr
-dUB
-dUB
+eAL
+eAL
 vSj
 sAb
 sAb
@@ -104266,9 +104772,9 @@ fiU
 mdl
 gmi
 kuF
-dUB
+eAL
 pTq
-dUB
+eAL
 sAb
 sAb
 sAb
@@ -104523,9 +105029,9 @@ eAL
 eAL
 eAL
 eAL
-dUB
-dUB
-dUB
+eAL
+eAL
+eAL
 sAb
 sAb
 sAb
@@ -165684,7 +166190,7 @@ wKe
 vSj
 vSj
 vSj
-rPR
+iJa
 bZf
 bZf
 bZf
@@ -165940,8 +166446,8 @@ wKe
 wKe
 vSj
 vSj
-wLd
-jpK
+qsW
+mOe
 bZf
 hex
 jZx
@@ -166198,7 +166704,7 @@ wKe
 vSj
 vSj
 sGY
-nHD
+nTE
 bZf
 vfU
 wgB
@@ -166455,7 +166961,7 @@ wKe
 wKe
 vSj
 vSj
-pqs
+xIB
 bZf
 ubb
 yhb
@@ -166706,13 +167212,13 @@ wKe
 wKe
 wKe
 wKe
-wKe
-wKe
-wKe
+eAL
+eAL
+eAL
 wKe
 vSj
 vSj
-vSj
+gjZ
 bZf
 bZf
 cVa
@@ -166959,17 +167465,17 @@ wKe
 wKe
 wKe
 wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-vSj
-vSj
-vSj
-vSj
+dUB
+dUB
+dUB
+dUB
+eAL
+hjF
+fYy
+wIm
+wIm
+wIm
+bbk
 rPR
 bZf
 bZf
@@ -167215,14 +167721,14 @@ wKe
 wKe
 wKe
 wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
+dUB
+dUB
+mJh
+uqS
+dUB
+qLa
+bfn
+eAL
 vSj
 vSj
 vSj
@@ -167471,16 +167977,16 @@ wKe
 wKe
 wKe
 wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-vSj
+dUB
+dUB
+wem
+bkK
+dUB
+dUB
+eAL
+vjE
+eAL
+eAL
 vSj
 vSj
 pqs
@@ -167728,16 +168234,16 @@ wKe
 wKe
 wKe
 wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
+dUB
+gIH
+dVi
+vbq
+dUB
+oea
+oea
+bkO
+mdJ
+eAL
 vSj
 vSj
 vSj
@@ -167985,17 +168491,17 @@ wKe
 wKe
 wKe
 wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
+dUB
+tPw
+mic
+tMZ
+iei
+qsu
+sLR
+uOd
+xWr
+vWt
+vSj
 vSj
 vSj
 wZj
@@ -168242,16 +168748,16 @@ wKe
 wKe
 wKe
 wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
+dUB
+goC
+rTF
+vtC
+dUB
+pRm
+klU
+sXk
+rdd
+eAL
 wKe
 vSj
 vSj
@@ -168499,18 +169005,18 @@ wKe
 wKe
 wKe
 wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-vSj
-vSj
+dUB
+giE
+jzV
+jsG
+dUB
+jLs
+qhW
+jvR
+eAL
+eAL
+eAL
+eAL
 vSj
 vSj
 aXZ
@@ -168756,18 +169262,18 @@ wKe
 wKe
 wKe
 wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-vSj
+dUB
+dUB
+dUB
+dUB
+dUB
+uDE
+qhW
+ktP
+kiE
+qZT
+qZT
+eAL
 vSj
 vSj
 bZV
@@ -169013,18 +169519,18 @@ wKe
 wKe
 wKe
 wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-vSj
-vSj
+eAL
+uPO
+ppe
+alf
+eAL
+yji
+kie
+gSo
+kiE
+qZT
+qZT
+eAL
 vSj
 wLd
 jpK
@@ -169270,18 +169776,18 @@ wKe
 wKe
 wKe
 wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-vSj
-vSj
-vSj
+eAL
+eAL
+ocN
+bcK
+oXN
+gCM
+rgB
+ktP
+kiE
+qZT
+qZT
+eAL
 wLd
 jpK
 hMk
@@ -169528,18 +170034,18 @@ wKe
 kPv
 wKe
 wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-wKe
-kPv
-kPv
-vSj
-vSj
-wLd
-jpK
+eAL
+eAL
+edQ
+eAL
+hNp
+gQh
+qxi
+eAL
+eAL
+eAL
+eAL
+rPR
 jpK
 qAp
 gqm
@@ -169786,16 +170292,16 @@ kPv
 kPv
 wKe
 wKe
-wKe
-wKe
-wKe
-wKe
-kPv
-kPv
-kPv
+eAL
+eAL
+eAL
+vWt
+vWt
+vWt
+eAL
 kPv
 vSj
-rPR
+wLd
 jpK
 jpK
 cbf


### PR DESCRIPTION

## About The Pull Request
Fixes FoxHole and Rimpoint to be at par with Delta\* when it comes to ArcMining.

\*Both maps don't have the space for a premade setup preallocated and I'd rather let it be sandboxed like it is there tbh

Also fixes #673 and adds a new cute little chapel office there to replace the old one
## Why It's Good For The Game
Map parity good, cozy good
## Changelog
:cl:
add: Rimpoint now has a crematorium. Oops?
/:cl:
