### PR TITLE
Foxhole + Rimpoint - Arcmining Rigs

### DIFF
--- a/_maps/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/map_files/FoxHoleStation/foxholestation.dmm
@@ -42954,8 +42954,6 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/east,
-/obj/item/boulder_beacon,
-/obj/structure/rack,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "xsP" = (

--- a/_maps/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/map_files/FoxHoleStation/foxholestation.dmm
@@ -1940,10 +1940,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"bcP" = (
-/obj/structure/ladder,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/aft/greater)
 "bdc" = (
 /turf/closed/wall,
 /area/station/engineering/main)
@@ -4882,6 +4878,24 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/locker)
+"cCG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 1
+	},
+/obj/machinery/bouldertech/refinery/smelter,
+/turf/open/floor/iron/smooth_large,
+/area/station/cargo/warehouse)
 "cCP" = (
 /obj/machinery/computer/teleporter{
 	dir = 8
@@ -5280,19 +5294,15 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "cQM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/structure/railing/corner{
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/smooth_edge,
 /area/station/cargo/warehouse)
 "cQP" = (
@@ -5592,6 +5602,14 @@
 	},
 /turf/open/openspace,
 /area/station/maintenance/aft/greater)
+"cZS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/station/cargo/warehouse)
 "das" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/reflector/box/anchored,
@@ -9440,6 +9458,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/fore)
+"ffi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/conveyor_switch/oneway{
+	id = "mining";
+	dir = 1;
+	pixel_x = 12
+	},
+/turf/open/floor/iron/smooth,
+/area/station/cargo/warehouse)
 "ffq" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -13395,6 +13425,22 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"huG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_large,
+/area/station/cargo/warehouse)
 "hvj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -13516,6 +13562,8 @@
 /obj/machinery/door/airlock/mining,
 /obj/effect/turf_decal/tile/brown/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/bitrunning/den)
 "hyU" = (
@@ -16870,6 +16918,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron/smooth_edge,
 /area/station/cargo/warehouse)
 "jle" = (
@@ -17476,7 +17525,8 @@
 "jDf" = (
 /obj/effect/spawner/random/structure/chair_maintenance,
 /obj/effect/spawner/random/maintenance,
-/turf/open/floor/catwalk_floor,
+/obj/structure/lattice/catwalk,
+/turf/open/openspace,
 /area/station/maintenance/aft/greater)
 "jDO" = (
 /obj/structure/railing{
@@ -19165,12 +19215,6 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "kzZ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -24097,24 +24141,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"nzg" = (
-/obj/effect/decal/cleanable/oil/streak,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing,
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_edge{
-	dir = 1
-	},
-/area/station/cargo/warehouse)
 "nzz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/bot_white,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "nzP" = (
@@ -28081,6 +28112,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/bitrunning/den)
 "pJu" = (
@@ -30080,20 +30113,11 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "qMI" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/spawner/random/structure/crate,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/conveyor{
+	id = "mining"
 	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "qMJ" = (
 /obj/effect/turf_decal/stripes/line,
@@ -30796,7 +30820,6 @@
 /turf/open/floor/wood/large,
 /area/station/service/chapel)
 "reg" = (
-/obj/item/stack/tile/iron/smooth,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34948,18 +34971,12 @@
 	},
 /area/station/medical/chemistry)
 "tnc" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/machinery/bouldertech/brm,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth_large,
+/obj/machinery/conveyor{
+	id = "mining"
+	},
+/turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "tnG" = (
 /obj/machinery/vending/coffee,
@@ -37369,6 +37386,24 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"uDL" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor/inverted{
+	dir = 10;
+	id = "mining"
+	},
+/turf/open/floor/iron/smooth_large,
+/area/station/cargo/warehouse)
 "uDM" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
@@ -40778,20 +40813,13 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "wlI" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/conveyor/inverted{
+	dir = 9;
+	id = "mining"
 	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/start/cargo_technician,
-/turf/open/floor/iron/smooth_large,
+/obj/machinery/bouldertech/refinery,
+/turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "wmm" = (
 /obj/structure/table,
@@ -43530,15 +43558,6 @@
 "xIZ" = (
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
-"xJc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_edge{
-	dir = 1
-	},
-/area/station/cargo/warehouse)
 "xJk" = (
 /obj/machinery/computer/arcade/orion_trail{
 	dir = 4
@@ -138614,7 +138633,7 @@ dEx
 pie
 hcL
 aLm
-bcP
+iGo
 iGo
 weK
 kbP
@@ -141935,8 +141954,8 @@ hef
 aVR
 aVR
 qaY
-xJc
 bUA
+ffi
 hef
 izw
 jkN
@@ -142192,7 +142211,7 @@ gKv
 hyy
 wqk
 gKv
-nhx
+cZS
 tnc
 qMI
 wlI
@@ -142449,10 +142468,10 @@ flD
 frI
 ixH
 wqk
-nzg
-kcy
-kcy
-kcy
+nhx
+cCG
+huG
+uDL
 cQM
 kbP
 onp

--- a/_maps/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/map_files/RimPoint/RimPoint.dmm
@@ -2882,12 +2882,9 @@
 /turf/open/floor/glass/reinforced,
 /area/station/ai_monitored/command/nuke_storage)
 "bpD" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/computer/shuttle/mining{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/north,
-/obj/item/boulder_beacon,
-/obj/structure/rack,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "bpG" = (
@@ -2997,7 +2994,6 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
 	},
-/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "bsl" = (
@@ -4409,6 +4405,18 @@
 	},
 /turf/open/floor/wood/large,
 /area/taeloth)
+"bYk" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 1
+	},
+/obj/machinery/bouldertech/refinery/smelter,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningoffice)
 "bYD" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -5051,13 +5059,16 @@
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/warehouse)
 "clI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/turf/open/floor/iron/diagonal,
 /area/station/cargo/miningoffice)
 "clL" = (
 /obj/structure/cable,
@@ -7855,6 +7866,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/item/stack/tile/iron/base,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "dzX" = (
@@ -9340,13 +9352,11 @@
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain)
 "ehw" = (
-/obj/machinery/computer/security/mining{
-	dir = 8
+/obj/effect/landmark/start/shaft_miner,
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/diagonal,
 /area/station/cargo/miningoffice)
 "ehB" = (
 /obj/structure/rack,
@@ -14120,6 +14130,13 @@
 /obj/structure/stairs/west,
 /turf/open/floor/plating,
 /area/station/command/bridge)
+"ghF" = (
+/obj/effect/landmark/start/shaft_miner,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningoffice)
 "ghL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -14806,13 +14823,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"gwO" = (
-/obj/structure/closet/crate,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
 "gxf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -16810,13 +16820,6 @@
 /obj/effect/turf_decal/bot_blue,
 /turf/open/floor/iron,
 /area/station/medical/storage)
-"hoX" = (
-/obj/structure/closet/crate,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
 "hpk" = (
 /obj/structure/dresser,
 /turf/open/floor/wood/parquet,
@@ -16884,7 +16887,6 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
 	},
-/obj/effect/landmark/start/shaft_miner,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -19721,6 +19723,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
+"iGW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "iGZ" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -19857,6 +19864,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/textured_large,
 /area/station/security/brig)
+"iKp" = (
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningoffice)
 "iKt" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark/smooth_half,
@@ -20736,6 +20750,15 @@
 "jex" = (
 /turf/open/misc/dirt/jungle,
 /area/station/security/prison/garden)
+"jeG" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 4
+	},
+/obj/machinery/bouldertech/refinery,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningoffice)
 "jfx" = (
 /obj/structure/sink/directional/west,
 /obj/effect/turf_decal/siding/blue{
@@ -22559,6 +22582,13 @@
 /obj/structure/railing,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"jSQ" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningoffice)
 "jSU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -23418,12 +23448,6 @@
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/taeloth)
-"kjr" = (
-/obj/structure/closet/crate,
-/obj/effect/turf_decal/bot,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
 "kjx" = (
 /obj/effect/turf_decal/siding/dark_red/corner{
 	dir = 1
@@ -23585,14 +23609,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/commissary)
-"knY" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/obj/effect/landmark/start/shaft_miner,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
 "kob" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -25847,7 +25863,8 @@
 /area/station/service/theater)
 "lqA" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/start/cargo_technician,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "lqY" = (
@@ -26084,6 +26101,15 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
+"lwq" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/machinery/conveyor/inverted{
+	dir = 10;
+	id = "mining"
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningoffice)
 "lwL" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/machinery/camera/directional/north{
@@ -26466,10 +26492,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
 "lHS" = (
-/obj/structure/closet/crate/secure/loot,
-/obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/closed/wall,
 /area/station/cargo/warehouse)
 "lHY" = (
 /turf/closed/wall,
@@ -27827,6 +27851,18 @@
 "mlr" = (
 /turf/open/floor/wood,
 /area/station/commons/dorms/room3)
+"mlD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/taeloth)
 "mlJ" = (
 /obj/machinery/photocopier,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
@@ -32466,11 +32502,13 @@
 /turf/open/floor/engine/hull/reinforced/taeloth,
 /area/taeloth)
 "orM" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/machinery/camera/directional/south{
+/obj/machinery/camera/directional/west{
 	c_tag = "Cargo - Mining Office"
 	},
+/obj/machinery/conveyor{
+	id = "mining"
+	},
+/obj/machinery/bouldertech/brm,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "orX" = (
@@ -35692,6 +35730,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"pME" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/taeloth)
 "pNg" = (
 /obj/effect/turf_decal/trimline/dark_red,
 /obj/effect/turf_decal/trimline/dark_red/filled/mid_joiner,
@@ -36669,6 +36720,13 @@
 	dir = 1
 	},
 /area/station/security/range)
+"qjl" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningoffice)
 "qjo" = (
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo"
@@ -36683,6 +36741,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "qjz" = (
@@ -40368,13 +40427,15 @@
 /turf/open/floor/plating,
 /area/station/commons/locker)
 "rKK" = (
-/obj/structure/closet/crate,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/camera/directional/east{
-	c_tag = "Cargo - Warehouse"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "rKU" = (
@@ -41003,6 +41064,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
+"rZp" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/station/cargo/miningoffice)
 "rZB" = (
 /obj/structure/table/reinforced,
 /obj/item/pipe_dispenser,
@@ -41101,15 +41169,20 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Cargo - Warehouse"
+	},
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "scm" = (
@@ -41641,6 +41714,10 @@
 /area/station/security/interrogation)
 "smQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "smX" = (
@@ -43039,6 +43116,14 @@
 /obj/effect/turf_decal/stripes/blue/end,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"sRZ" = (
+/obj/effect/landmark/start/cargo_technician,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
+"sSf" = (
+/obj/structure/closet/secure_closet/miner,
+/turf/open/floor/iron,
+/area/station/cargo/miningoffice)
 "sSy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -43674,6 +43759,15 @@
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/station/security/brig/entrance)
+"tha" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningoffice)
 "thc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/herringbone,
@@ -46528,13 +46622,14 @@
 /turf/open/openspace,
 /area/taeloth)
 "uwk" = (
-/obj/machinery/computer/shuttle/mining{
+/obj/effect/landmark/start/shaft_miner,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/diagonal,
 /area/station/cargo/miningoffice)
 "uwm" = (
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -47219,7 +47314,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
 "uKE" = (
-/obj/item/stack/tile/iron/base,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -47231,6 +47325,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/structure/closet/crate/secure/loot,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "uKO" = (
@@ -48418,9 +48513,6 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "vnQ" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "vnR" = (
@@ -48888,9 +48980,10 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "vyb" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/machinery/conveyor_switch/oneway{
+	id = "mining";
+	pixel_x = -11
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "vyd" = (
@@ -49381,6 +49474,14 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/dorms/room1)
+"vJC" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/machinery/conveyor/inverted{
+	dir = 9;
+	id = "mining"
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningoffice)
 "vJG" = (
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 8
@@ -49656,10 +49757,10 @@
 /turf/open/floor/wood/parquet,
 /area/taeloth)
 "vPT" = (
-/obj/machinery/computer/order_console/mining,
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 4
 	},
+/obj/machinery/computer/order_console/mining,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "vRk" = (
@@ -51484,6 +51585,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"wHO" = (
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/computer/security/mining{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningoffice)
 "wHS" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 10
@@ -52909,14 +53020,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "xow" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 1
-	},
 /obj/structure/chair/office{
-	dir = 4
+	dir = 8
 	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/turf/open/floor/iron/diagonal,
 /area/station/cargo/miningoffice)
 "xoB" = (
 /turf/open/floor/glass/reinforced,
@@ -95999,7 +96109,7 @@ azi
 aUQ
 tti
 tti
-tti
+eog
 eog
 ydW
 eog
@@ -96256,14 +96366,14 @@ jPN
 qGV
 nEE
 lHS
-tti
+wHO
 bpD
 tSZ
 xPG
 bsg
 orM
+vJC
 eog
-sAb
 sAb
 sAb
 sAb
@@ -96512,15 +96622,15 @@ qZy
 dzV
 vKH
 qjx
-gwO
 tti
+rZp
 xow
 clI
 oBI
 hrg
 vyb
+tha
 eog
-sAb
 sAb
 sAb
 wvK
@@ -96769,15 +96879,15 @@ hBc
 uKE
 lqA
 smQ
-hoX
 tti
+ghF
 ehw
 uwk
 gPC
-knY
+bsg
 vnQ
+jeG
 eog
-sAb
 sAb
 sAb
 sAb
@@ -97024,17 +97134,17 @@ sAb
 tti
 gNi
 tXs
-hBc
-qGV
-kjr
+sRZ
+iGW
 tti
-csn
+jSQ
+qjl
+sSf
+gPC
+bYk
+iKp
+lwq
 eog
-izq
-eog
-eog
-eog
-sAb
 sAb
 sAb
 sAb
@@ -97284,14 +97394,14 @@ sbO
 rKK
 sVv
 tti
-tti
-sAb
+eog
 csn
-sOg
+eog
+izq
+eog
 csn
-sAb
-sAb
-xEZ
+eog
+eog
 sAb
 sAb
 sAb
@@ -97535,21 +97645,21 @@ sAb
 sAb
 sAb
 sAb
+tti
 mda
 mda
 cfc
 mda
 mda
-tti
-jpx
-jpx
-eog
-ndx
-eog
-jpx
-jpx
-mhb
+sAb
+sAb
+csn
+sOg
+csn
+sAb
+sAb
 xEZ
+sAb
 sAb
 sAb
 sAb
@@ -97792,21 +97902,21 @@ sAb
 sAb
 sAb
 sAb
+sAb
 mda
 mft
 tgu
 gze
 mda
-tNM
-iYL
-iYL
-iYL
-pey
-iYL
-iYL
-iYL
-tNM
-sAb
+jpx
+jpx
+eog
+ndx
+eog
+jpx
+jpx
+mhb
+xEZ
 sAb
 sAb
 sAb
@@ -98049,16 +98159,16 @@ wvK
 sAb
 sAb
 sAb
+sAb
 mda
 mda
 mda
 mda
 mda
-tNM
 iYL
 iYL
 iYL
-iYL
+pey
 iYL
 iYL
 iYL
@@ -99081,17 +99191,17 @@ sAb
 sAb
 sAb
 sAb
-xEZ
-mhb
-jpx
-jpx
-jpx
-jpx
-jpx
-jpx
-jpx
-mhb
-xEZ
+sAb
+tNM
+iYL
+iYL
+iYL
+iYL
+iYL
+iYL
+iYL
+tNM
+sAb
 wKe
 wKe
 wKe
@@ -99338,17 +99448,17 @@ sAb
 sAb
 sAb
 sAb
-sAb
 xEZ
-sAb
-sAb
-sAb
-sAb
-sAb
-sAb
-sAb
-wKe
-wKe
+mhb
+jpx
+jpx
+jpx
+jpx
+jpx
+jpx
+jpx
+mhb
+xEZ
 wKe
 wKe
 wKe
@@ -99596,7 +99706,7 @@ sAb
 sAb
 sAb
 sAb
-sAb
+xEZ
 sAb
 sAb
 sAb
@@ -162560,8 +162670,8 @@ kPv
 nHD
 qAp
 qyx
-dVW
-jpK
+qvC
+vZr
 jpK
 nHD
 nHD
@@ -162816,9 +162926,9 @@ kPv
 kPv
 nHD
 qAp
-qyx
+pME
+mlD
 dVW
-jpK
 nHD
 nHD
 kPv
@@ -163071,12 +163181,12 @@ kPv
 kPv
 kPv
 kPv
+nHD
 mda
 mda
 rFD
 mda
 mda
-nHD
 kPv
 kPv
 nHD
@@ -163328,12 +163438,12 @@ kPv
 kPv
 kPv
 kPv
+kPv
 mda
 hwu
 gBs
 joR
 mda
-kPv
 kPv
 kPv
 kPv
@@ -163585,12 +163695,12 @@ kPv
 kPv
 kPv
 kPv
-mda
-mda
-mda
-mda
-mda
 kPv
+mda
+mda
+mda
+mda
+mda
 kPv
 kPv
 kPv

--- a/_maps/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/map_files/RimPoint/RimPoint.dmm
@@ -26491,10 +26491,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
-"lHS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall,
-/area/station/cargo/warehouse)
 "lHY" = (
 /turf/closed/wall,
 /area/station/maintenance/radshelter/sci)
@@ -96365,7 +96361,7 @@ ouf
 jPN
 qGV
 nEE
-lHS
+tti
 wHO
 bpD
 tSZ


### PR DESCRIPTION
Supercedes #688 as the rest of the PR *should* already be addressed. In theory. Also makes it possible to grab the mining points out of the machines on both. Lol

:cl:
add: Foxhole and Rimpoint now have pre-set rigs for boulder mining.
/:cl:
