### PR TITLE
Update headshot regex filter

### DIFF
--- a/local/code/modules/client/preferences/headshot.dm
+++ b/local/code/modules/client/preferences/headshot.dm
@@ -20,23 +20,23 @@
 
 	var/find_index = findtext(value, "https://")
 	if(find_index != 1)
-		to_chat(usr, span_warning("Your link must be https!"))
+		to_chat(usr, SPAN_BOX_ALERT(RED, "Your headshot link must be https!"))
 		return
 
 	if(!findtext(value, "."))
-		to_chat(usr, span_warning("Invalid link!"))
+		to_chat(usr, SPAN_BOX_ALERT(RED, "Invalid headshot link!"))
 		return
 	var/list/value_split = splittext(value, ".")
 
 	// extension will always be the last entry
 	var/extension = value_split[length(value_split)]
 	if(!(extension in valid_extensions))
-		to_chat(usr, span_warning("The image must be one of the following extensions: '[english_list(valid_extensions)]'"))
+		to_chat(usr, SPAN_BOX_ALERT(RED, "Headshot image must be one of the following extensions: '[english_list(valid_extensions)]'"))
 		return
 
 	find_index = findtext(value, link_regex)
 	if(find_index != 9)
-		to_chat(usr, span_warning("The image must be hosted on one of the following sites: 'Gyazo, Discord'"))
+		to_chat(usr, SPAN_BOX_ALERT(RED, "Headshot image must be hosted on one of the following sites: Effigy, F-List, Discord, Lensdump, Gyazo"))
 		return
 
 	if(stored_link[usr.ckey] != value)

--- a/local/code/modules/client/preferences/headshot.dm
+++ b/local/code/modules/client/preferences/headshot.dm
@@ -7,7 +7,7 @@
 	maximum_value_length = MAX_MESSAGE_LEN
 	/// Assoc list of ckeys and their link, used to cut down on chat spam
 	var/list/stored_link = list()
-	var/static/link_regex = regex("i.gyazo.com|media.discordapp.net|cdn.discordapp.com")
+	var/static/link_regex = regex("cdn.effigy.se|i.gyazo.com|media.discordapp.net|cdn.discordapp.com|a.l3n.co|b.l3n.co|c.l3n.co|static.f-list.net/images/") //effigy, gyazo, discord, lensdump, f-list
 	var/static/list/valid_extensions = list("jpg", "png", "jpeg") // Regex works fine, if you know how it works
 
 /datum/preference/text/headshot/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)


### PR DESCRIPTION
## About The Pull Request

Adds F-List and Effigy CDN to the allowed headshots regex

## Changelog

:cl: LT3
code: F-List and Effigy CDN can be used for headshot links
/:cl: