### PR TITLE
Fix early return in airlock engineering override

### DIFF
--- a/local/code/game/machinery/doors/airlock_override.dm
+++ b/local/code/game/machinery/doors/airlock_override.dm
@@ -107,8 +107,7 @@
 ///When the signal is received of a changed security level, check if it's orange.
 /obj/machinery/door/airlock/check_security_level(datum/source, level)
 	. = ..()
-	var/area/source_area = get_area(src)
-	if(!source_area.engineering_override_eligible)
+	if(!door_area.engineering_override_eligible)
 		return
 
 	if(isnull(req_access) && isnull(req_one_access)) // no restrictions, no problem
@@ -150,6 +149,9 @@ GLOBAL_VAR_INIT(force_eng_override, FALSE)
 /obj/machinery/door/airlock/proc/force_eng_override(datum/source, status)
 	SIGNAL_HANDLER
 
+	if(!door_area.engineering_override_eligible)
+		return
+
 	if(isnull(req_access) && isnull(req_one_access)) // no restrictions, no problem
 		return
 
@@ -159,14 +161,14 @@ GLOBAL_VAR_INIT(force_eng_override, FALSE)
 		update_appearance()
 		return
 
-	if(!door_area.engineering_override_eligible)
-		return
-
 	normalspeed = FALSE
 	update_appearance()
 
 /obj/machinery/door/airlock/proc/update_fire_status(datum/source, fire)
 	SIGNAL_HANDLER
+
+	if(!door_area.engineering_override_eligible)
+		return
 
 	if(isnull(req_access) && isnull(req_one_access)) // no restrictions, no problem
 		return
@@ -175,9 +177,6 @@ GLOBAL_VAR_INIT(force_eng_override, FALSE)
 	if(!fire_active && !engineering_override)
 		normalspeed = TRUE
 		update_appearance()
-		return
-
-	if(!door_area.engineering_override_eligible)
 		return
 
 	normalspeed = FALSE


### PR DESCRIPTION
## About The Pull Request

🆑 LT3
fix: Fixed ineligible airlocks from receiving engineering override when activated from the communications console
/:cl:
