### PR TITLE
Subtle PDA messaging

### DIFF
--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_data.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_data.dm
@@ -136,7 +136,7 @@ GLOBAL_LIST_EMPTY_TYPED(pda_messengers, /datum/computer_file/program/messenger)
 	/// Whether or not the message is hidden from ghostchat
 	var/subtle // EffigyEdit Add - Subtle texting
 
-/datum/pda_message/New(message, outgoing, timestamp, photo_name = null, everyone = FALSE)
+/datum/pda_message/New(message, outgoing, timestamp, photo_name = null, everyone = FALSE, subtle = FALSE)
 	src.message = message
 	src.outgoing = outgoing
 	src.timestamp = timestamp

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_data.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_data.dm
@@ -133,6 +133,8 @@ GLOBAL_LIST_EMPTY_TYPED(pda_messengers, /datum/computer_file/program/messenger)
 	var/everyone
 	/// The station time at which this message was made.
 	var/timestamp
+	/// Whether or not the message is hidden from ghostchat
+	var/subtle // EffigyEdit Add - Subtle texting
 
 /datum/pda_message/New(message, outgoing, timestamp, photo_name = null, everyone = FALSE)
 	src.message = message
@@ -140,6 +142,7 @@ GLOBAL_LIST_EMPTY_TYPED(pda_messengers, /datum/computer_file/program/messenger)
 	src.timestamp = timestamp
 	src.photo_name = photo_name
 	src.everyone = everyone
+	src.subtle = subtle // EffigyEdit Add - Subtle texting
 
 /// Returns an associative list of the message's data, used for ui_data calls.
 /datum/pda_message/proc/get_ui_data(mob/user)
@@ -149,4 +152,5 @@ GLOBAL_LIST_EMPTY_TYPED(pda_messengers, /datum/computer_file/program/messenger)
 	data["photo_path"] = photo_name ? SSassets.transport.get_asset_url(photo_name) : null
 	data["everyone"] = everyone
 	data["timestamp"] = timestamp
+	data["subtle"] = subtle // EffigyEdit Add - Subtle texting
 	return data

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -293,7 +293,7 @@
 
 				return disk.send_virus(computer, target_messenger.computer, usr, params["message"])
 
-			return send_message(usr, params["message"], list(target))
+			return send_message(usr, params["message"], list(target), subtle = params["subtle"]) // EffigyEdit Change - Subtle texting - Original: return send_message(usr, params["message"], list(target))
 
 		if("PDA_clearPhoto")
 			selected_image = null
@@ -386,7 +386,7 @@
 //////////////////////
 
 /// Brings up the quick reply prompt to send a message.
-/datum/computer_file/program/messenger/proc/quick_reply_prompt(mob/living/user, datum/pda_chat/chat)
+/datum/computer_file/program/messenger/proc/quick_reply_prompt(mob/living/user, datum/pda_chat/chat, subtle = FALSE) // EffigyEdit Change - Subtle texting - Original: /datum/computer_file/program/messenger/proc/quick_reply_prompt(mob/living/user, datum/pda_chat/chat)
 	if(!istype(chat))
 		return
 	var/datum/computer_file/program/messenger/target = chat.recipient?.resolve()
@@ -397,7 +397,7 @@
 		return
 	var/target_name = target.computer.saved_identification
 	var/input_message = tgui_input_text(user, "Enter [mime_mode ? "emojis":"a message"]", "NT Messaging[target_name ? " ([target_name])" : ""]", encode = FALSE)
-	send_message(user, input_message, list(chat))
+	send_message(user, input_message, list(chat), subtle = subtle) // EffigyEdit Change - Subtle texting - Original: send_message(user, input_message, list(chat))
 
 /// Helper proc that sends a message to everyone
 /datum/computer_file/program/messenger/proc/send_message_to_all(mob/living/user, message)
@@ -466,7 +466,7 @@
 	return message
 
 /// Sends a message to targets via PDA. When sending to everyone, set `everyone` to true so the message is formatted accordingly
-/datum/computer_file/program/messenger/proc/send_message(atom/source, message, list/targets, everyone = FALSE)
+/datum/computer_file/program/messenger/proc/send_message(atom/source, message, list/targets, everyone = FALSE, subtle = FALSE) // EffigyEdit Change - Subtle texting - Original: /datum/computer_file/program/messenger/proc/send_message(atom/source, message, list/targets, everyone = FALSE)
 	var/mob/living/sender
 	if(isliving(source))
 		sender = source
@@ -474,6 +474,13 @@
 	if(!message)
 		return FALSE
 
+	// EffigyEdit Add - Subtle texting
+	// If "subtle" it wont be sent to ghostchats.
+	// A message is "subtle" if it begins with "#", the below code also removes it from the sent message.
+	if(findtext(message,"#") == 1)
+	subtle = TRUE
+		message = copytext(message,2,0)
+	// EffigyEdit Add End
 
 	// upgrade the image asset to a permanent key
 	var/photo_asset_key = selected_image
@@ -535,11 +542,11 @@
 		target_chats += target_chat
 		target_messengers += target_messenger
 
-	if(!send_message_signal(source, message, target_messengers, photo_asset_key, everyone))
+	if(!send_message_signal(source, message, target_messengers, photo_asset_key, everyone, FALSE, null, null, subtle)) // EffigyEdit Change - Subtle texting - Original: if(!send_message_signal(source, message, target_messengers, photo_asset_key, everyone))
 		return FALSE
 
 	// Log it in our logs
-	var/datum/pda_message/message_datum = new(message, TRUE, station_time_timestamp(PDA_MESSAGE_TIMESTAMP_FORMAT), photo_asset_key, everyone)
+	var/datum/pda_message/message_datum = new(message, TRUE, station_time_timestamp(PDA_MESSAGE_TIMESTAMP_FORMAT), photo_asset_key, everyone, subtle = subtle) // EffigyEdit Change - Subtle texting - Original: var/datum/pda_message/message_datum = new(message, TRUE, station_time_timestamp(PDA_MESSAGE_TIMESTAMP_FORMAT), photo_asset_key, everyone)
 	for(var/datum/pda_chat/target_chat as anything in target_chats)
 		target_chat.add_message(message_datum, show_in_recents = !everyone)
 		target_chat.unread_messages = 0
@@ -565,8 +572,7 @@
 
 	return send_message_signal(sender, message, targets, fake_photo, FALSE, TRUE, fake_name, fake_job)
 
-/datum/computer_file/program/messenger/proc/send_message_signal(atom/source, message, list/datum/computer_file/program/messenger/targets, photo_path = null, everyone = FALSE, rigged = FALSE, fake_name = null, fake_job = null)
-	var/mob/sender
+/datum/computer_file/program/messenger/proc/send_message_signal(atom/source, message, list/datum/computer_file/program/messenger/targets, photo_path = null, everyone = FALSE, rigged = FALSE, fake_name = null, fake_job = null, subtle = FALSE) // EffigyEdit Change - Subtle texting - Original: /datum/computer_file/program/messenger/proc/send_message_signal(atom/source, message, list/datum/computer_file/program/messenger/targets, photo_path = null, everyone = FALSE, rigged = FALSE, fake_name = null, fake_job = null)	var/mob/sender
 	if(ismob(source))
 		sender = source
 		if(!sender.can_perform_action(computer, ALLOW_RESTING))
@@ -601,6 +607,7 @@
 		"everyone" = everyone,
 		"photo" = photo_path,
 		"automated" = FALSE,
+		"subtle" = subtle, // EffigyEdit Add - Subtle texting
 	))
 	if(rigged) //Will skip the message server and go straight to the hub so it can't be cheesed by disabling the message server machine
 		signal.data["fakename"] = fake_name
@@ -624,7 +631,7 @@
 		shell_addendum = "[circuit.parent.get_creator()] "
 
 	// Log in the talk log
-	source.log_talk(message, LOG_PDA, tag="[shell_addendum][rigged ? "Rigged" : ""] PDA: [computer.saved_identification] to [signal.format_target()]")
+	source.log_talk(message, LOG_PDA, tag="[shell_addendum][rigged ? "Rigged" : ""] PDA[subtle ? "(Subtle)" : ""]: [computer.saved_identification] to [signal.format_target()]") // EffigyEdit Change - Subtle texting - Original: source.log_talk(message, LOG_PDA, tag="[shell_addendum][rigged ? "Rigged" : ""] PDA: [computer.saved_identification] to [signal.format_target()]")
 	if(rigged)
 		log_bomber(sender, "sent a rigged PDA message (Name: [fake_name]. Job: [fake_job]) to [english_list(stringified_targets)] [!is_special_character(sender) ? "(SENT BY NON-ANTAG)" : ""]")
 
@@ -633,10 +640,18 @@
 	// Show it to ghosts
 	var/ghost_message = span_game_say("[span_name("[source]")] [rigged ? "(as [span_name(fake_name)]) Rigged " : ""]PDA Message --> [span_name("[signal.format_target()]")]: \"[signal.format_message()]\"")
 	var/list/message_listeners = GLOB.dead_player_list + GLOB.current_observers_list
-	for(var/mob/listener as anything in message_listeners)
-		if(!(get_chat_toggles(listener) & CHAT_GHOSTPDA))
-			continue
-		to_chat(listener, "[FOLLOW_LINK(listener, source)] [ghost_message]")
+	/** EffigyEdit Change - Subtle texting - Original:
+	//	for(var/mob/listener as anything in message_listeners)
+	//	if(!(get_chat_toggles(listener) & CHAT_GHOSTPDA))
+	//		continue
+	//	to_chat(listener, "[FOLLOW_LINK(listener, source)] [ghost_message]")
+	*/
+	if(!subtle)
+		for(var/mob/listener as anything in message_listeners)
+			if(!(get_chat_toggles(listener) & CHAT_GHOSTPDA))
+				continue
+			to_chat(listener, "[FOLLOW_LINK(listener, source)] [ghost_message]")
+	// EffigyEdit Change End
 
 	if(sender)
 		to_chat(sender, span_info("PDA message sent to [signal.format_target()]: \"[message]\""))
@@ -665,7 +680,7 @@
 
 	// don't create a new chat for rigged messages, make it a one off notif
 	if(!is_rigged)
-		var/datum/pda_message/message = new(signal.data["message"], FALSE, station_time_timestamp(PDA_MESSAGE_TIMESTAMP_FORMAT), signal.data["photo"], signal.data["everyone"])
+		var/datum/pda_message/message = new(signal.data["message"], FALSE, station_time_timestamp(PDA_MESSAGE_TIMESTAMP_FORMAT), signal.data["photo"], signal.data["everyone"], signal.data["subtle"]) // EffigyEdit Change - Subtle texting - Original: var/datum/pda_message/message = new(signal.data["message"], FALSE, station_time_timestamp(PDA_MESSAGE_TIMESTAMP_FORMAT), signal.data["photo"], signal.data["everyone"])
 
 		chat = find_chat_by_recipient(is_fake_user ? fake_name : sender_ref, is_fake_user)
 		if(!istype(chat))

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -396,7 +396,7 @@
 		chat.can_reply = FALSE
 		return
 	var/target_name = target.computer.saved_identification
-	var/input_message = tgui_input_text(user, "Enter [mime_mode ? "emojis":"a message"]", "NT Messaging[target_name ? " ([target_name])" : ""]", encode = FALSE)
+	var/input_message = tgui_input_text(user, "Enter [mime_mode ? "emojis":"a message"]. Start with # for subtle.", "NT Messaging[target_name ? " ([target_name])" : ""]", encode = FALSE)
 	send_message(user, input_message, list(chat), subtle = subtle) // EffigyEdit Change - Subtle texting - Original: send_message(user, input_message, list(chat))
 
 /// Helper proc that sends a message to everyone
@@ -632,7 +632,7 @@
 		shell_addendum = "[circuit.parent.get_creator()] "
 
 	// Log in the talk log
-	source.log_talk(message, LOG_PDA, tag="[shell_addendum][rigged ? "Rigged" : ""] PDA[subtle ? "(Subtle)" : ""]: [computer.saved_identification] to [signal.format_target()]") // EffigyEdit Change - Subtle texting - Original: source.log_talk(message, LOG_PDA, tag="[shell_addendum][rigged ? "Rigged" : ""] PDA: [computer.saved_identification] to [signal.format_target()]")
+	source.log_talk(message, subtle ? LOG_SUBTLE : LOG_PDA, tag="[shell_addendum][rigged ? "Rigged" : ""] PDA: [computer.saved_identification] to [signal.format_target()]")// EffigyEdit Change - Subtle texting - Original: source.log_talk(message, LOG_PDA, tag="[shell_addendum][rigged ? "Rigged" : ""] PDA: [computer.saved_identification] to [signal.format_target()]")
 	if(rigged)
 		log_bomber(sender, "sent a rigged PDA message (Name: [fake_name]. Job: [fake_job]) to [english_list(stringified_targets)] [!is_special_character(sender) ? "(SENT BY NON-ANTAG)" : ""]")
 

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -477,9 +477,9 @@
 	// EffigyEdit Add - Subtle texting
 	// If "subtle" it wont be sent to ghostchats.
 	// A message is "subtle" if it begins with "#", the below code also removes it from the sent message.
-	if(findtext(message,"#") == 1)
-	subtle = TRUE
-		message = copytext(message,2,0)
+	if(findtext(message,"#", 1) == TRUE)
+		subtle = TRUE
+		message = copytext(message, 2, 0)
 	// EffigyEdit Add End
 
 	// upgrade the image asset to a permanent key
@@ -572,7 +572,8 @@
 
 	return send_message_signal(sender, message, targets, fake_photo, FALSE, TRUE, fake_name, fake_job)
 
-/datum/computer_file/program/messenger/proc/send_message_signal(atom/source, message, list/datum/computer_file/program/messenger/targets, photo_path = null, everyone = FALSE, rigged = FALSE, fake_name = null, fake_job = null, subtle = FALSE) // EffigyEdit Change - Subtle texting - Original: /datum/computer_file/program/messenger/proc/send_message_signal(atom/source, message, list/datum/computer_file/program/messenger/targets, photo_path = null, everyone = FALSE, rigged = FALSE, fake_name = null, fake_job = null)	var/mob/sender
+/datum/computer_file/program/messenger/proc/send_message_signal(atom/source, message, list/datum/computer_file/program/messenger/targets, photo_path = null, everyone = FALSE, rigged = FALSE, fake_name = null, fake_job = null, subtle = FALSE) // EffigyEdit Change - Subtle texting - Original: /datum/computer_file/program/messenger/proc/send_message_signal(atom/source, message, list/datum/computer_file/program/messenger/targets, photo_path = null, everyone = FALSE, rigged = FALSE, fake_name = null, fake_job = null)
+	var/mob/sender
 	if(ismob(source))
 		sender = source
 		if(!sender.can_perform_action(computer, ALLOW_RESTING))

--- a/tgui/packages/tgui/interfaces/NtosMessenger/ChatScreen.tsx
+++ b/tgui/packages/tgui/interfaces/NtosMessenger/ChatScreen.tsx
@@ -33,6 +33,7 @@ type ChatScreenState = {
   message: string;
   previewingImage?: string;
   selectingPhoto: boolean;
+  subtleMode: boolean; // EffigyEdit Add - Subtle texting
 };
 
 const READ_UNREADS_TIME_MS = 1000;
@@ -46,6 +47,7 @@ export class ChatScreen extends Component<ChatScreenProps, ChatScreenState> {
     message: '',
     selectingPhoto: false,
     canSend: true,
+    subtleMode: false, // EffigyEdit Add - Subtle texting
   };
 
   constructor(props: ChatScreenProps) {
@@ -60,6 +62,7 @@ export class ChatScreen extends Component<ChatScreenProps, ChatScreenState> {
     this.trySetReadTimeout = this.trySetReadTimeout.bind(this);
     this.tryClearReadTimeout = this.tryClearReadTimeout.bind(this);
     this.clearUnreads = this.clearUnreads.bind(this);
+    this.handleToggleSubtle = this.handleToggleSubtle.bind(this); // EffigyEdit Add - Subtle texting
   }
 
   componentDidMount() {
@@ -152,6 +155,7 @@ export class ChatScreen extends Component<ChatScreenProps, ChatScreenState> {
     act('PDA_sendMessage', {
       ref: ref,
       message: this.state.message,
+      subtle: this.state.subtleMode, // EffigyEdit Add - Subtle texting
     });
 
     this.setState({ message: '', canSend: false });
@@ -161,6 +165,14 @@ export class ChatScreen extends Component<ChatScreenProps, ChatScreenState> {
   handleMessageInput(_: any, val: string) {
     this.setState({ message: val });
   }
+
+  // EffigyEdit Add - Subtle texting
+  handleToggleSubtle() {
+    this.setState((state) => ({
+      subtleMode: !state.subtleMode,
+    }));
+  }
+  // EffigyEdit Add End
 
   render() {
     const { act } = useBackend();
@@ -174,7 +186,9 @@ export class ChatScreen extends Component<ChatScreenProps, ChatScreenState> {
       sendingVirus,
       unreads,
     } = this.props;
-    const { message, canSend, previewingImage, selectingPhoto } = this.state;
+    // EffigyEdit Change - Subtle texting - Original: const { message, canSend, previewingImage, selectingPhoto } = this.state;
+    const { message, canSend, previewingImage, selectingPhoto, subtleMode } =
+      this.state;
 
     let filteredMessages: JSX.Element[] = [];
 
@@ -197,6 +211,7 @@ export class ChatScreen extends Component<ChatScreenProps, ChatScreenState> {
             everyone={message.everyone}
             photoPath={message.photo_path}
             timestamp={message.timestamp}
+            subtle={message.subtle} // EffigyEdit Add - Subtle texting
             onPreviewImage={
               message.photo_path
                 ? () => this.setState({ previewingImage: message.photo_path! })
@@ -269,6 +284,16 @@ export class ChatScreen extends Component<ChatScreenProps, ChatScreenState> {
       const buttons = canReply ? (
         <>
           <Stack.Item>{attachmentButton}</Stack.Item>
+          {/* EffigyEdit Add - Subtle texting */}
+          <Stack.Item>
+            <Button
+              tooltip="Toggle subtle mode; messages sent will be hidden from prying eyes."
+              icon={subtleMode ? 'fa-ear-deaf' : 'fa-ear-listen'}
+              backgroundColor={subtleMode ? `hsl(281, 39%, 59%)` : ''}
+              onClick={this.handleToggleSubtle}
+            />
+          </Stack.Item>
+          {/* EffigyEdit Add End */}
           <Stack.Item>
             <Button
               tooltip="Send"
@@ -396,16 +421,38 @@ type ChatMessageProps = {
   timestamp: string;
   photoPath?: string;
   onPreviewImage?: () => void;
+  subtle: BooleanLike; // EffigyEdit Add - Subtle texting
 };
 
 const ChatMessage = (props: ChatMessageProps) => {
-  const { message, everyone, outgoing, photoPath, timestamp, onPreviewImage } =
-    props;
+  // EffigyEdit Change - Subtle texting - Original: const { message, everyone, outgoing, photoPath, timestamp, onPreviewImage } = props;
+  const {
+    message,
+    everyone,
+    outgoing,
+    photoPath,
+    timestamp,
+    onPreviewImage,
+    subtle,
+  } = props;
+  // EffigyEdit Change End
 
   const displayMessage = decodeHtmlEntities(message);
 
   return (
-    <Box className={`NtosChatMessage${outgoing ? '_outgoing' : ''}`}>
+    // EffigyEdit Change - Subtle texting - Original: <Box className={`NtosChatMessage${outgoing ? '_outgoing' : ''}`}>
+    <Box
+      className={`NtosChatMessage${
+        subtle
+          ? outgoing
+            ? '_subtle_outgoing'
+            : '_subtle'
+          : outgoing
+            ? '_outgoing'
+            : ''
+      }`}
+    >
+      {/* EffigyEdit Change End */}
       <Box className="NtosChatMessage__content">
         <Box as="span">{displayMessage}</Box>
         <Tooltip content={timestamp} position={outgoing ? 'left' : 'right'}>

--- a/tgui/packages/tgui/interfaces/NtosMessenger/types.tsx
+++ b/tgui/packages/tgui/interfaces/NtosMessenger/types.tsx
@@ -6,6 +6,7 @@ export type NtMessage = {
   photo_path?: string;
   everyone: BooleanLike;
   timestamp: string;
+  subtle: BooleanLike; // EffigyEdit Add - Subtle texting
 };
 
 export type NtPicture = {

--- a/tgui/packages/tgui/styles/interfaces/NtosMessenger.scss
+++ b/tgui/packages/tgui/styles/interfaces/NtosMessenger.scss
@@ -6,6 +6,10 @@
 
 $msgcolor-outgoing: hsl(213, 50%, 35%);
 $msgcolor-incoming: hsl(213, 0%, 20%);
+// EffigyEdit Add - Subtle texting
+$msgcolor-subtle-outgoing: hsl(281, 39%, 59%);
+$msgcolor-subtle-incoming: hsl(281, 15%, 59%);
+// EffigyEdit Add End
 
 $msgpadding: 0.7rem;
 
@@ -49,6 +53,20 @@ $msgpadding: 0.7rem;
     text-align: right;
     float: right;
   }
+
+  // EffigyEdit Add - Subtle texting
+  &_subtle_outgoing {
+    @extend .NtosChatMessage;
+    background-color: $msgcolor-subtle-outgoing;
+    text-align: right;
+    float: right;
+  }
+
+  &_subtle {
+    @extend .NtosChatMessage;
+    background-color: $msgcolor-subtle-incoming;
+  }
+  // EffigyEdit Add End
 
   &__timestamp {
     height: 0.9rem;

--- a/tgui/packages/tgui/styles/interfaces/NtosMessenger.scss
+++ b/tgui/packages/tgui/styles/interfaces/NtosMessenger.scss
@@ -4,11 +4,11 @@
 @use '../functions';
 @use '../colors';
 
-$msgcolor-outgoing: hsl(213, 50%, 35%);
-$msgcolor-incoming: hsl(213, 0%, 20%);
+$msgcolor-outgoing: #006b8f; // EffigyEdit Change
+$msgcolor-incoming: #424651; // EffigyEdit Change
 // EffigyEdit Add - Subtle texting
-$msgcolor-subtle-outgoing: hsl(281, 39%, 59%);
-$msgcolor-subtle-incoming: hsl(281, 15%, 59%);
+$msgcolor-subtle-outgoing: #a56ebf;
+$msgcolor-subtle-incoming: #7c538f;
 // EffigyEdit Add End
 
 $msgpadding: 0.7rem;


### PR DESCRIPTION
Port, original PR: https://github.com/NovaSector/NovaSector/pull/1329

## About The Pull Request

When you begin a PDA message with the "#" symbol, it is marked as "subtle" stopping it from being shown to ghost chats. For when you have something you REALLY wanna say but you only want a certain someone to see it. (unless your pda gets stolen, good luck explaining it then.)

A rigged message (PDA Bobm (spelt correctly)) will never be subtle, ever.

## Changelog

:cl: LordVoidron, vinylspiders
add: Private (no ghost) pda messaging, done by adding "#" to start of PDA message.
qol: Added button to NTOS messenger TGUI to toggle private messaging.
/:cl: