### PR TITLE
Updated non-contextual player preferences

### DIFF
--- a/local/code/modules/client/preferences/erp_preferences.dm
+++ b/local/code/modules/client/preferences/erp_preferences.dm
@@ -128,10 +128,13 @@
 	savefile_key = "erp_status_pref"
 
 /datum/preference/choiced/erp_status/init_possible_values()
-	return list("Yes - Switch", "Yes - Sub", "Yes - Dom", "Check OOC", "Ask", "No", "Yes")
+	return list (
+	"Top - Dom", "Top - Switch", "Top - Sub", "Verse-Top - Dom", "Verse-Top - Switch", "Verse-Top - Sub", "Verse - Dom", "Verse - Switch", "Verse - Sub",
+	"Verse-Bottom - Dom", "Verse-Bottom - Switch", "Verse-Bottom - Sub", "Bottom - Dom", "Bottom- Switch", "Bottom - Sub", "Check OOC Panel", "Ask (L)OOC", "No", "Yes"
+	)
 
 /datum/preference/choiced/erp_status/create_default_value()
-	return "No"
+	return "Check OOC Panel"
 
 /datum/preference/choiced/erp_status/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))


### PR DESCRIPTION
## About The Pull Request

Updates the ERP status preference with an improved set of options, splitting dom/sub/switch and top/bottom/vers into distinct options.

Port of https://github.com/NovaSector/NovaSector/pull/1527

## Changelog

🆑 Nerev4r
qol: Interaction preferences have been expanded for better clarity
/:cl: