### PR TITLE
Cargochat Console Fixes

### DIFF
--- a/_maps/effigy/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/effigy/map_files/FoxHoleStation/foxholestation.dmm
@@ -6320,9 +6320,6 @@
 	dir = 5
 	},
 /obj/item/kirbyplants/random,
-/obj/item/kirbyplants/random,
-/obj/item/kirbyplants/random,
-/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/science)
 "dpx" = (

--- a/_maps/effigy/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/effigy/map_files/FoxHoleStation/foxholestation.dmm
@@ -6319,6 +6319,10 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 5
 	},
+/obj/item/kirbyplants/random,
+/obj/item/kirbyplants/random,
+/obj/item/kirbyplants/random,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/science)
 "dpx" = (
@@ -8380,9 +8384,6 @@
 /turf/closed/wall,
 /area/station/tcommsat/server)
 "ezI" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
@@ -8561,7 +8562,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/atmos)
 "eDX" = (
-/obj/structure/chair/office/light,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
 "eEl" = (
@@ -15413,10 +15413,10 @@
 "iwM" = (
 /obj/machinery/light/directional/south,
 /obj/structure/cable,
-/obj/machinery/modular_computer/preset/cargochat/service{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
 /turf/open/floor/iron/textured_large,
 /area/station/hallway/secondary/service)
 "ixm" = (
@@ -18294,8 +18294,7 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/genetics)
 "jYJ" = (
-/obj/machinery/recharge_station,
-/obj/effect/turf_decal/bot_red,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
@@ -20526,12 +20525,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
-"lro" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/turf/open/floor/carpet/cyan,
-/area/station/medical/break_room)
 "lrx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -21027,7 +21020,7 @@
 /obj/machinery/modular_computer/preset/cargochat/engineering,
 /obj/effect/turf_decal/tile/brown/fourcorners,
 /obj/effect/turf_decal/siding/wideplating_new/end{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron/checker,
 /area/station/engineering/break_room)
@@ -25530,6 +25523,9 @@
 "oqZ" = (
 /obj/effect/turf_decal/tile/brown/fourcorners,
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/obj/machinery/modular_computer/preset/cargochat/medical{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "orl" = (
@@ -27234,11 +27230,9 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/brig/upper)
 "pln" = (
-/obj/effect/turf_decal/tile/brown/fourcorners,
-/obj/effect/turf_decal/siding/wideplating_new/end{
-	dir = 4
-	},
-/turf/open/floor/iron/checker,
+/obj/machinery/computer/monitor,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/station/engineering/break_room)
 "plT" = (
 /obj/effect/spawner/random/engineering/canister,
@@ -27944,6 +27938,9 @@
 "pEF" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/modular_computer/preset/cargochat/service{
+	dir = 8
+	},
 /turf/open/floor/iron/textured_large,
 /area/station/hallway/secondary/service)
 "pEO" = (
@@ -34457,6 +34454,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "tcp" = (
@@ -36041,10 +36039,8 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "tSj" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/siding/red{
 	dir = 8
 	},
@@ -36063,7 +36059,7 @@
 "tSF" = (
 /obj/structure/cable,
 /obj/machinery/computer/order_console/cook{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/textured_large,
@@ -36286,8 +36282,10 @@
 /turf/open/floor/iron/diagonal,
 /area/station/security/prison/safe)
 "tYp" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
 /turf/open/floor/wood/parquet,
 /area/station/medical/break_room)
 "tYz" = (
@@ -39432,13 +39430,13 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/medical/chemistry)
 "vEY" = (
-/obj/machinery/modular_computer/preset/cargochat/medical{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown/fourcorners,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/parquet,
 /area/station/medical/break_room)
 "vFh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -149387,7 +149385,7 @@ xeX
 cXV
 fZa
 qlt
-lro
+fZa
 ezI
 xeX
 hIO

--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -3774,14 +3774,10 @@
 	},
 /area/station/commons/storage/primary)
 "bBA" = (
-/obj/machinery/modular_computer/preset/cargochat/engineering,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 10
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/wideplating_new{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/engineering/hallway)
 "bBF" = (
 /obj/effect/turf_decal/siding/wideplating_new/end{
@@ -13346,11 +13342,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "fqS" = (
-/obj/effect/turf_decal/tile/brown/diagonal_edge,
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 10
-	},
-/turf/open/floor/iron/dark/diagonal,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/catwalk_floor/iron,
 /area/station/medical/medbay/central)
 "frg" = (
 /obj/structure/bodycontainer/morgue{
@@ -14405,9 +14398,7 @@
 /area/station/security/brig/entrance)
 "fOg" = (
 /obj/effect/turf_decal/siding/wideplating_new/light,
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 1
-	},
+/obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/station/science)
 "fOm" = (
@@ -24248,10 +24239,7 @@
 /turf/open/floor/grass,
 /area/taeloth)
 "jQQ" = (
-/obj/effect/turf_decal/tile/brown/fourcorners,
-/obj/effect/turf_decal/siding/wideplating_new/dark/end{
-	dir = 1
-	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "jRc" = (
@@ -29731,13 +29719,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
-"mhw" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/trimline/dark_red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "mhC" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 6
@@ -34693,6 +34674,7 @@
 /area/station/ai_monitored/command/storage/eva)
 "okV" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/structure/chair/plastic,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "okW" = (
@@ -37283,7 +37265,7 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/east,
-/obj/item/kirbyplants/random,
+/obj/machinery/photocopier,
 /turf/open/floor/mineral/plastitanium/red,
 /area/station/security/office)
 "pmN" = (
@@ -40363,8 +40345,10 @@
 	},
 /area/station/science/xenobiology)
 "qxR" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
+/obj/machinery/modular_computer/preset/cargochat/medical,
+/obj/effect/turf_decal/tile/brown/diagonal_edge,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
 	},
 /obj/structure/railing{
 	dir = 8
@@ -40372,10 +40356,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/diagonal,
 /area/station/medical/medbay/central)
 "qxT" = (
 /turf/open/floor/iron/dark,
@@ -40898,6 +40879,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qGV" = (
@@ -43001,13 +42983,7 @@
 /turf/open/floor/plating/reinforced,
 /area/station/maintenance/department/medical)
 "rAv" = (
-/obj/machinery/modular_computer/preset/cargochat/medical,
-/obj/effect/turf_decal/tile/brown/diagonal_edge,
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 6
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/catwalk_floor/iron,
 /area/station/medical/medbay/central)
 "rAK" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -43459,6 +43435,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/command/heads_quarters/hop)
+"rIj" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/structure/chair,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "rIo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/green/visible/layer2{
 	dir = 8
@@ -44339,9 +44320,12 @@
 /area/station/engineering/engine_smes)
 "sbd" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
+	dir = 10
 	},
-/obj/effect/turf_decal/siding/wideplating_new,
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 10
+	},
+/obj/machinery/modular_computer/preset/cargochat/engineering,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "sbh" = (
@@ -55831,7 +55815,6 @@
 /turf/closed/wall,
 /area/station/service/bar)
 "wKl" = (
-/obj/machinery/photocopier,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 9
@@ -58529,7 +58512,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/brown/fourcorners,
-/obj/effect/turf_decal/siding/wideplating_new/dark/end,
+/obj/effect/turf_decal/siding/wideplating_new/dark/end{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "xNc" = (
@@ -83450,7 +83435,7 @@ rCE
 xUc
 xUc
 xUc
-mhw
+upj
 okV
 jcy
 bep
@@ -83708,7 +83693,7 @@ xUc
 xSr
 lpA
 upj
-okV
+rIj
 uOh
 hed
 afz

--- a/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
+++ b/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
@@ -4980,6 +4980,9 @@
 /turf/open/floor/plating,
 /area/station/service/janitor/wetworks/deck_two)
 "bfP" = (
+/obj/machinery/modular_computer/preset/cargochat/engineering{
+	dir = 8
+	},
 /turf/open/floor/wood/parquet,
 /area/station/engineering/break_room)
 "bfQ" = (
@@ -39535,7 +39538,6 @@
 /turf/open/floor/iron/smooth,
 /area/station/commons/vacant_room)
 "jlF" = (
-/obj/structure/railing/corner/end,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -39933,12 +39935,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
+/obj/structure/railing/corner/end,
 /turf/open/floor/wood/parquet,
 /area/station/engineering/break_room)
 "jqO" = (
@@ -44957,10 +44954,8 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard/greater)
 "kBl" = (
-/obj/structure/rack,
+/obj/structure/table,
 /obj/item/mod/module/plasma_stabilizer,
-/obj/item/mod/module/thermal_regulator,
-/obj/item/mod/module/signlang_radio,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/smooth_large,
 /area/station/medical/storage)
@@ -55257,6 +55252,7 @@
 /obj/effect/turf_decal/siding/wideplating_new/light{
 	dir = 6
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/diagonal,
 /area/station/science/research)
 "naa" = (
@@ -56287,13 +56283,15 @@
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/secondary/entry)
 "nmi" = (
-/obj/machinery/modular_computer/preset/cargochat/engineering{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/structure/rack,
+/obj/item/lightreplacer{
+	pixel_y = 7
+	},
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/wood/parquet,
 /area/station/engineering/break_room)
 "nmo" = (
@@ -67562,7 +67560,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/warning{
-	dir = 1
+	dir = 5
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/medical/storage)
@@ -67969,10 +67967,13 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/siding/wideplating_new/end{
-	dir = 1
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 6
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/machinery/modular_computer/preset/cargochat/service{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "qdj" = (
@@ -72307,14 +72308,7 @@
 /turf/open/floor/wood,
 /area/station/maintenance/floor1/starboard/aft)
 "rbc" = (
-/obj/machinery/modular_computer/preset/cargochat/service{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/siding/wideplating_new/end,
+/obj/structure/hedge,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "rbg" = (
@@ -78506,6 +78500,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small/directional/east,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/herringbone,
 /area/station/security/office)
 "sCV" = (
@@ -96073,11 +96068,6 @@
 /turf/open/misc/beach/sand,
 /area/station/maintenance/floor2/starboard)
 "wPq" = (
-/obj/structure/rack,
-/obj/item/lightreplacer{
-	pixel_y = 7
-	},
-/obj/item/storage/box/lights/mixed,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "wPr" = (
@@ -96681,11 +96671,13 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/table,
 /obj/structure/railing{
 	dir = 8
 	},
 /obj/machinery/incident_display/delam/directional/south,
+/obj/structure/chair/office{
+	dir = 4
+	},
 /turf/open/floor/wood/parquet,
 /area/station/engineering/break_room)
 "wWy" = (
@@ -100494,10 +100486,10 @@
 /turf/open/floor/iron/white/smooth_half,
 /area/station/science/ordnance/storage)
 "xPB" = (
-/obj/effect/turf_decal/trimline/brown/warning{
-	dir = 5
-	},
 /obj/machinery/airalarm/directional/south,
+/obj/structure/table,
+/obj/item/mod/module/signlang_radio,
+/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron/smooth_large,
 /area/station/medical/storage)
 "xPH" = (


### PR DESCRIPTION
Every cargochat console has been moved around ever-so-slightly to accommodate losing it's twin.