### PR TITLE
Latejoin Spawnpoint Preference - Marries Cryo & The Interlink into the Broader Ecosystem

### DIFF
--- a/_maps/effigy/RandomRuins/OceanRuins/ocean_bubble_rally.dmm
+++ b/_maps/effigy/RandomRuins/OceanRuins/ocean_bubble_rally.dmm
@@ -574,7 +574,7 @@
 /turf/open/floor/plating,
 /area/ruin/ocean/bubble)
 "tY" = (
-/obj/machinery/cryopod/quiet{
+/obj/machinery/cryopod/ruin{
 	dir = 4
 	},
 /obj/machinery/computer/cryopod/directional/north,
@@ -1042,7 +1042,7 @@
 /turf/open/floor/iron,
 /area/ruin/ocean/bubble)
 "EU" = (
-/obj/machinery/cryopod/quiet{
+/obj/machinery/cryopod/ruin{
 	dir = 4
 	},
 /obj/machinery/light/directional/west,

--- a/_maps/effigy/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/effigy/map_files/FoxHoleStation/foxholestation.dmm
@@ -25817,13 +25817,13 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "ozS" = (
-/obj/effect/turf_decal/trimline/green/warning{
+/obj/effect/turf_decal/trimline/blue/warning{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/mid_joiner{
+/obj/effect/turf_decal/trimline/blue/mid_joiner{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_edge{
@@ -42204,7 +42204,7 @@
 /obj/effect/turf_decal/trimline/white/filled/warning{
 	dir = 8
 	},
-/obj/machinery/cryopod{
+/obj/machinery/cryopod/no_latejoin{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_edge{
@@ -43545,13 +43545,13 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/mess)
 "xJP" = (
-/obj/effect/turf_decal/trimline/green/warning{
+/obj/effect/turf_decal/trimline/blue/warning{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/mid_joiner{
+/obj/effect/turf_decal/trimline/blue/mid_joiner{
 	dir = 8
 	},
 /obj/machinery/computer/cryopod/directional/west,

--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -19113,7 +19113,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/cryopod{
+/obj/machinery/cryopod/no_latejoin{
 	dir = 4
 	},
 /turf/open/floor/iron/diagonal,

--- a/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
+++ b/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
@@ -80248,7 +80248,7 @@
 /turf/open/misc/dirt/dark/station,
 /area/station/service/hydroponics/garden)
 "sZd" = (
-/obj/machinery/cryopod{
+/obj/machinery/cryopod/no_latejoin{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue/full,

--- a/_maps/effigy/map_files/generic/CentCom_z2_effigy.dmm
+++ b/_maps/effigy/map_files/generic/CentCom_z2_effigy.dmm
@@ -28,6 +28,7 @@
 	dir = 8
 	},
 /obj/structure/sign/poster/official/help_others/directional/east,
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/interlink)
 "au" = (
@@ -67,6 +68,7 @@
 /obj/structure/chair/sofa/bench/right{
 	dir = 8
 	},
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/interlink)
 "aM" = (
@@ -333,6 +335,7 @@
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
 	},
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/interlink)
 "dU" = (
@@ -446,6 +449,7 @@
 /obj/structure/fluff/fake_camera{
 	dir = 5
 	},
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/interlink)
 "eX" = (
@@ -697,6 +701,7 @@
 "hP" = (
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/light/directional/east,
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/titanium/blue/accessible/south,
 /area/centcom/interlink)
 "hS" = (
@@ -840,6 +845,7 @@
 /area/centcom/interlink)
 "jt" = (
 /obj/structure/chair/sofa/corp,
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/interlink)
 "jx" = (
@@ -1209,6 +1215,7 @@
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
 	},
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/interlink)
 "oJ" = (
@@ -1259,7 +1266,7 @@
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "pf" = (
-/obj/machinery/cryopod,
+/obj/machinery/cryopod/no_latejoin,
 /obj/effect/turf_decal/tile/blue/full,
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
@@ -1478,6 +1485,7 @@
 	dir = 8
 	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/interlink)
 "rk" = (
@@ -1683,6 +1691,7 @@
 /area/centcom/interlink)
 "tF" = (
 /obj/effect/turf_decal/bot_white,
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/titanium/blue/accessible/south,
 /area/centcom/interlink)
 "tL" = (
@@ -1963,6 +1972,7 @@
 	dir = 4
 	},
 /obj/machinery/status_display/random_message/motivational/directional/west,
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/interlink)
 "wW" = (
@@ -2073,6 +2083,7 @@
 	dir = 4
 	},
 /obj/machinery/status_display/random_message/motivational/directional/west,
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/interlink)
 "yX" = (
@@ -2150,6 +2161,7 @@
 /obj/structure/chair/sofa/corp{
 	dir = 1
 	},
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/interlink)
 "AK" = (
@@ -2424,6 +2436,7 @@
 "EA" = (
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/light/directional/east,
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/titanium/blue/accessible,
 /area/centcom/interlink)
 "EG" = (
@@ -2887,6 +2900,7 @@
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
 	},
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/interlink)
 "KX" = (
@@ -3056,6 +3070,7 @@
 /obj/structure/chair/sofa/bench/solo{
 	dir = 4
 	},
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/interlink)
 "Nf" = (
@@ -3067,7 +3082,7 @@
 /turf/open/floor/iron/large,
 /area/centcom/interlink)
 "Nk" = (
-/obj/machinery/cryopod,
+/obj/machinery/cryopod/no_latejoin,
 /obj/effect/turf_decal/tile/blue/full,
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
@@ -3248,6 +3263,7 @@
 	dir = 8
 	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/interlink)
 "Ph" = (
@@ -3673,6 +3689,7 @@
 /area/centcom/interlink)
 "Tp" = (
 /obj/effect/turf_decal/bot_white,
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/titanium/blue/accessible,
 /area/centcom/interlink)
 "Tu" = (
@@ -3819,6 +3836,7 @@
 /obj/structure/fluff/fake_camera{
 	dir = 1
 	},
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/interlink)
 "Uy" = (
@@ -4276,6 +4294,7 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
 	},
+/obj/effect/landmark/latejoin_interlink,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/interlink)
 "Zq" = (

--- a/_maps/effigy/templates/automapper/icebox/icebox_cryo.dmm
+++ b/_maps/effigy/templates/automapper/icebox/icebox_cryo.dmm
@@ -73,16 +73,6 @@
 /obj/machinery/camera/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/commons/cryo)
-"J" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/commons/cryo)
 "K" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -105,6 +95,11 @@
 "T" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"Y" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron,
+/area/station/commons/cryo)
 
 (1,1,1) = {"
 C
@@ -117,7 +112,7 @@ y
 (2,1,1) = {"
 C
 E
-J
+b
 b
 v
 y
@@ -126,8 +121,8 @@ y
 C
 k
 a
-a
-v
+Y
+C
 y
 "}
 (4,1,1) = {"

--- a/_maps/effigy/templates/automapper/metastation/metastation_cryo.dmm
+++ b/_maps/effigy/templates/automapper/metastation/metastation_cryo.dmm
@@ -156,6 +156,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
+"M" = (
+/turf/closed/wall,
+/area/station/commons/fitness/recreation)
 "N" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -290,7 +293,7 @@ W
 m
 J
 m
-O
+M
 a
 a
 a

--- a/code/__DEFINES/_effigy/jobs.dm
+++ b/code/__DEFINES/_effigy/jobs.dm
@@ -1,3 +1,8 @@
+// Latejoin locations
+#define JOB_LATEJOINPREF_ARRIVALS "The Arrivals Shuttle"
+#define JOB_LATEJOINPREF_CRYO "Cryogenic Storage"
+#define JOB_LATEJOINPREF_INTERLINK "The Interlink"
+
 // Just keeping this easy to maintain in the future.
 #define JOB_UNAVAILABLE_QUIRK (JOB_UNAVAILABLE_ANTAG_INCOMPAT + 1)
 #define JOB_UNAVAILABLE_SPECIES (JOB_UNAVAILABLE_QUIRK + 1)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -479,7 +479,7 @@
 		log_mapping("Job [title] ([type]) couldn't find a round start spawn point.")
 
 /// Finds a valid latejoin spawn point, checking for events and special conditions.
-/datum/job/proc/get_latejoin_spawn_point(var/our_joiner) // Effigy Edit - added "var/mob/our_joiner"
+/datum/job/proc/get_latejoin_spawn_point(our_joiner) // Effigy Edit - added "our_joiner"
 	if(length(GLOB.jobspawn_overrides[title])) //We're doing something special today.
 		return pick(GLOB.jobspawn_overrides[title])
 	/// EFFIGY EDIT BEGIN - SPAWN PREFS ///

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -484,17 +484,12 @@
 		return pick(GLOB.jobspawn_overrides[title])
 	/// EFFIGY EDIT BEGIN - SPAWN PREFS ///
 	if(our_joiner && istype(our_joiner, /mob))
-		to_chat(world, "our_joiner found; value is [our_joiner]") // SHOG DEBUG
-		var/mob/dead/new_player/potential_alt_spawner
-		to_chat(world, "potential_alt_spawner found; value is [potential_alt_spawner]") // SHOG DEBUG
+		var/mob/dead/new_player/potential_alt_spawner = our_joiner
 		var/their_latejoin_pref = potential_alt_spawner?.client.prefs.read_preference(/datum/preference/choiced/latejoin_location)
-		to_chat(world, "their_latejoin_pref found; value is [their_latejoin_pref]") // SHOG DEBUG
-		if(length(their_latejoin_pref))
+		if(their_latejoin_pref)
 			if(their_latejoin_pref == JOB_LATEJOINPREF_INTERLINK && length(SSjob.latejoin_interlink_trackers))
-				to_chat(world, "FOUND INTERLINK PREF") // SHOG DEBUG
 				return pick(SSjob.latejoin_interlink_trackers)
 			if(their_latejoin_pref == JOB_LATEJOINPREF_CRYO)
-				to_chat(world, "FOUND CRYO PREF") // SHOG DEBUG
 				return pick(SSjob.latejoin_cryo_trackers)
 	/// EFFIGY EDIT END - SPAWN PREFS ///
 	if(length(SSjob.latejoin_trackers))

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -117,7 +117,7 @@
 	/// RPG job names, for the memes
 	var/rpg_title
 
-	/// Alternate titles to register as pointing to this job. 
+	/// Alternate titles to register as pointing to this job.
 	var/list/alternate_titles
 
 	/// Does this job ignore human authority?
@@ -479,9 +479,24 @@
 		log_mapping("Job [title] ([type]) couldn't find a round start spawn point.")
 
 /// Finds a valid latejoin spawn point, checking for events and special conditions.
-/datum/job/proc/get_latejoin_spawn_point()
+/datum/job/proc/get_latejoin_spawn_point(var/our_joiner) // Effigy Edit - added "var/mob/our_joiner"
 	if(length(GLOB.jobspawn_overrides[title])) //We're doing something special today.
 		return pick(GLOB.jobspawn_overrides[title])
+	/// EFFIGY EDIT BEGIN - SPAWN PREFS ///
+	if(our_joiner && istype(our_joiner, /mob))
+		to_chat(world, "our_joiner found; value is [our_joiner]") // SHOG DEBUG
+		var/mob/dead/new_player/potential_alt_spawner
+		to_chat(world, "potential_alt_spawner found; value is [potential_alt_spawner]") // SHOG DEBUG
+		var/their_latejoin_pref = potential_alt_spawner?.client.prefs.read_preference(/datum/preference/choiced/latejoin_location)
+		to_chat(world, "their_latejoin_pref found; value is [their_latejoin_pref]") // SHOG DEBUG
+		if(length(their_latejoin_pref))
+			if(their_latejoin_pref == JOB_LATEJOINPREF_INTERLINK && length(SSjob.latejoin_interlink_trackers))
+				to_chat(world, "FOUND INTERLINK PREF") // SHOG DEBUG
+				return pick(SSjob.latejoin_interlink_trackers)
+			if(their_latejoin_pref == JOB_LATEJOINPREF_CRYO)
+				to_chat(world, "FOUND CRYO PREF") // SHOG DEBUG
+				return pick(SSjob.latejoin_cryo_trackers)
+	/// EFFIGY EDIT END - SPAWN PREFS ///
 	if(length(SSjob.latejoin_trackers))
 		return pick(SSjob.latejoin_trackers)
 	return SSjob.get_last_resort_spawn_points()

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -201,7 +201,7 @@
 
 	hide_title_screen() // EffigyEdit Add - SPLASH
 	mind.late_joiner = TRUE
-	var/atom/destination = mind.assigned_role.get_latejoin_spawn_point()
+	var/atom/destination = mind.assigned_role.get_latejoin_spawn_point(src) // EFFIGY EDIT - Added "src"; Spawnprefs
 	if(!destination)
 		CRASH("Failed to find a latejoin spawn point.")
 	var/mob/living/character = create_character(destination)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -241,7 +241,7 @@
 		// EffigyEdit Change START - CUSTOMIZATION
 		var/chosen_rank = rank // put alt job here
 		GLOB.manifest.inject(humanc, humanc.client)
-		if(SSshuttle.arrivals)
+		if(SSshuttle.arrivals && humanc.client.prefs.read_preference(/datum/preference/choiced/latejoin_location) == JOB_LATEJOINPREF_ARRIVALS) /// EFFIGY EDIT - Latejoin Spawnpref
 			SSshuttle.arrivals.QueueAnnounce(humanc, chosen_rank)
 		else
 			announce_arrival(humanc, chosen_rank)

--- a/local/code/controllers/subsystem/job.dm
+++ b/local/code/controllers/subsystem/job.dm
@@ -1,3 +1,7 @@
+/datum/controller/subsystem/job
+	var/list/latejoin_interlink_trackers = list()
+	var/list/latejoin_cryo_trackers = list()
+
 /datum/controller/subsystem/job/proc/FreeRole(rank)
 	if(!rank)
 		return

--- a/local/code/game/machinery/cryopod.dm
+++ b/local/code/game/machinery/cryopod.dm
@@ -168,6 +168,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 	///Weakref to our controller
 	var/datum/weakref/control_computer_weakref
 	COOLDOWN_DECLARE(last_no_computer_message)
+
+	/// Can we be used as a latejoin spawnpoint?
+	var/latejoin_possible = TRUE
 	/// if false, plays announcement on cryo
 	var/quiet = FALSE
 
@@ -181,14 +184,19 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 	/// The rank (job title) of the mob that entered the cryopod, if it was a human. "N/A" by default.
 	var/stored_rank = "N/A"
 
+/obj/machinery/cryopod/no_latejoin
+	latejoin_possible = FALSE
 
-/obj/machinery/cryopod/quiet
+/obj/machinery/cryopod/ruin
 	quiet = TRUE
+	latejoin_possible = FALSE
 
 /obj/machinery/cryopod/Initialize(mapload)
 	..()
 	if(!quiet)
 		GLOB.valid_cryopods += src
+	if(latejoin_possible)
+		SSjob.latejoin_cryo_trackers += src
 	return INITIALIZE_HINT_LATELOAD //Gotta populate the cryopod computer GLOB first
 
 /obj/machinery/cryopod/LateInitialize()
@@ -199,6 +207,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 /obj/machinery/cryopod/Destroy()
 	GLOB.valid_cryopods -= src
 	control_computer_weakref = null
+	SSjob.latejoin_cryo_trackers -= src // Prevents spawning in a cryopod that doesn't exist
 	return ..()
 
 /obj/machinery/cryopod/proc/find_control_computer(urgent = FALSE)

--- a/local/code/game/machinery/cryopod.dm
+++ b/local/code/game/machinery/cryopod.dm
@@ -210,6 +210,31 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 	SSjob.latejoin_cryo_trackers -= src // Prevents spawning in a cryopod that doesn't exist
 	return ..()
 
+/obj/machinery/cryopod/JoinPlayerHere(mob/joining_mob, buckle)
+	. = ..()
+	/// If you're not /mob/living; gtfo, none of this matters
+	if(!isliving(joining_mob))
+		return
+	/// Is someone already in this cryopod? If so; commit to comedy
+	if(stored_name)
+		var/mob/living/comedy_target = joining_mob
+		playsound(get_turf(src), 'sound/effects/meteorimpact.ogg', 100, TRUE)
+		playsound(src, 'sound/effects/smoke.ogg', 50, TRUE, -3)
+		var/datum/effect_system/fluid_spread/smoke/bad/smoke = new
+		smoke.set_up(1, holder = src, location = src)
+		smoke.start()
+		qdel(smoke) // We're done with you
+		comedy_target.Paralyze(8 SECONDS)
+		comedy_target.adjustStaminaLoss(40)
+		step_away(comedy_target, src)
+		shake_camera(comedy_target, 4, 3)
+		comedy_target.visible_message(
+			span_warning("[comedy_target] is suddenly shot out of the [src] in a puff of smoke!"),
+			span_userdanger("Your peaceful awakening is interrupted as [src] sends you flying!"),
+		)
+	else if(buckle)
+		close_machine(joining_mob)
+
 /obj/machinery/cryopod/proc/find_control_computer(urgent = FALSE)
 	for(var/cryo_console as anything in GLOB.cryopod_computers)
 		var/obj/machinery/computer/cryopod/console = cryo_console

--- a/local/code/game/objects/effects/landmarks.dm
+++ b/local/code/game/objects/effects/landmarks.dm
@@ -1,3 +1,11 @@
+/obj/effect/landmark/latejoin_interlink
+	name = "JoinLateInterlink"
+
+/obj/effect/landmark/latejoin_interlink/Initialize(mapload)
+	..()
+	SSjob.latejoin_interlink_trackers += loc
+	return INITIALIZE_HINT_QDEL
+
 /obj/effect/landmark/start/broadcast_team
 	name = JOB_BROADCAST_TEAM
 	icon_state = JOB_ASSISTANT // I don't think we're ready for the commitment that is maintaining these as modular icons.

--- a/local/code/modules/client/preferences/latejoin_location.dm
+++ b/local/code/modules/client/preferences/latejoin_location.dm
@@ -1,0 +1,13 @@
+/datum/preference/choiced/latejoin_location
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	savefile_key = "latejoin_location"
+	savefile_identifier = PREFERENCE_CHARACTER
+
+/datum/preference/choiced/latejoin_location/init_possible_values()
+	return list(JOB_LATEJOINPREF_ARRIVALS, JOB_LATEJOINPREF_CRYO, JOB_LATEJOINPREF_INTERLINK)
+
+/datum/preference/choiced/latejoin_location/create_default_value()
+	return JOB_LATEJOINPREF_ARRIVALS
+
+/datum/preference/choiced/latejoin_location/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6484,6 +6484,7 @@
 #include "local\code\modules\client\preferences\genitals.dm"
 #include "local\code\modules\client\preferences\ghost.dm"
 #include "local\code\modules\client\preferences\headshot.dm"
+#include "local\code\modules\client\preferences\latejoin_location.dm"
 #include "local\code\modules\client\preferences\laugh.dm"
 #include "local\code\modules\client\preferences\loadout_override_preference.dm"
 #include "local\code\modules\client\preferences\looc.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/effigy/latejoin_location.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/effigy/latejoin_location.tsx
@@ -1,0 +1,6 @@
+import { FeatureChoiced, FeatureDropdownInput } from '../../base';
+
+export const latejoin_location: FeatureChoiced = {
+  name: 'Latejoin Location',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION

## About The Pull Request
You ever notice that in spite of technical feature parity (and surpassment) in regards to the Interlink; you still had to go out of you way to catch the shuttle there? That wasn't actually the intent; it was a gameplay concession for the "short-term". But then I remembered that certain Polaris forks actually created a preference that let you choose your spawnpoint, one thing led to another; a few rock-against-wall rewrites later; and now we have this.

tl;dr, there is now a new per-character preference to opt into spawning at the Interlink or Cryo when you latejoin; making both actually interwoven with their intended purposes again. Oorah.

Draft while I check some hyper-specific edgecases.
## Why It's Good For The Game
Stops a few features from feeling disjointed; and adds a opt-in parity feature for those that want it. Also character customization.
## Changelog
:cl:
add: Each character can now opt into spawning in cryogenic storage or on the Interlink.
/:cl:
