### PR TITLE
Sigma Octantis Firedoor Audit

### DIFF
--- a/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
+++ b/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
@@ -209,7 +209,7 @@
 /turf/open/floor/plating/reinforced,
 /area/station/maintenance/starboard/greater)
 "acL" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
@@ -558,7 +558,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -4626,7 +4626,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating_new,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
@@ -6058,7 +6058,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating_new,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/machinery/duct/waste,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
@@ -9446,7 +9446,7 @@
 /turf/open/floor/iron/lowered,
 /area/station/maintenance/floor1/port/aft)
 "chZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/machinery/vending/boozeomat/all_access,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
@@ -11153,14 +11153,6 @@
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
-"cCB" = (
-/obj/effect/turf_decal/siding/wideplating_new,
-/obj/effect/turf_decal/siding/wideplating_new{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/storage)
 "cCI" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/bridge)
@@ -12058,7 +12050,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "cOF" = (
@@ -13293,7 +13285,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/firedoor/water_sensor/heavy,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/atmos)
 "daI" = (
@@ -14352,7 +14344,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating_new,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
@@ -14455,7 +14447,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/machinery/duct/waste,
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/floor1/aft)
@@ -15972,7 +15964,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/station/medical/treatment_center)
@@ -16803,7 +16795,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/floor2/aft)
 "dTb" = (
@@ -17402,7 +17394,7 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/atmos)
 "ebI" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
@@ -18738,7 +18730,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/aft)
 "eqY" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
@@ -20802,7 +20794,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/firedoor/water_sensor/heavy,
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/atmos)
@@ -21854,7 +21846,7 @@
 /turf/open/floor/iron/diagonal,
 /area/station/service/hydroponics/garden)
 "fbt" = (
-/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/firedoor/water_sensor/heavy,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
 	},
@@ -22514,17 +22506,6 @@
 /obj/structure/fans/tiny/shield,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
-"fiU" = (
-/obj/effect/turf_decal/siding/wideplating_new,
-/obj/effect/turf_decal/siding/wideplating_new{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/storage)
 "fja" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -25151,7 +25132,7 @@
 "fOY" = (
 /obj/machinery/duct/supply,
 /obj/structure/cable,
-/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/firedoor/water_sensor/heavy,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
 	},
@@ -26920,6 +26901,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/firedoor/water_sensor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "gkz" = (
@@ -31555,7 +31537,7 @@
 /turf/open/misc/asteroid/snow/standard_air,
 /area/station/maintenance/floor1/port/aft)
 "hnE" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
@@ -35057,7 +35039,7 @@
 /area/station/command/heads_quarters/rd)
 "ijg" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/effect/turf_decal/siding/wideplating_new/corner{
 	dir = 1
 	},
@@ -35784,7 +35766,7 @@
 /area/station/hallway/floor1/fore)
 "irv" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "iry" = (
@@ -36535,7 +36517,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "iAx" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
@@ -37043,6 +37025,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /obj/machinery/duct/waste,
+/obj/machinery/door/firedoor/water_sensor/heavy,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "iFV" = (
@@ -39289,7 +39272,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/station/security/brig)
@@ -39445,7 +39428,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
 /area/station/security/brig)
@@ -40348,7 +40331,7 @@
 /area/station/maintenance/floor1/port/aft)
 "jvP" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/structure/desk_bell{
 	pixel_x = 7;
 	pixel_y = 6
@@ -45372,7 +45355,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /turf/open/floor/iron/smooth_large,
 /area/station/security/brig)
 "kGs" = (
@@ -45386,7 +45369,7 @@
 /turf/open/floor/iron/diagonal,
 /area/station/command/heads_quarters/ce)
 "kGz" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
@@ -47005,7 +46988,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/structure/barricade/security,
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
@@ -48749,7 +48732,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating_new,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
@@ -49764,15 +49747,6 @@
 	},
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/floor2/aft)
-"lJW" = (
-/obj/effect/turf_decal/siding/wideplating_new,
-/obj/effect/turf_decal/siding/wideplating_new{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/duct/waste,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/storage)
 "lKd" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow/diagonal_centre,
@@ -53212,7 +53186,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/floor1/aft)
 "mBf" = (
@@ -53799,6 +53773,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/water_sensor,
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/cargo)
 "mIh" = (
@@ -54406,7 +54381,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "mQh" = (
-/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/firedoor/water_sensor/heavy,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
@@ -54795,7 +54770,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/firedoor/water_sensor/heavy,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/atmos)
 "mUv" = (
@@ -55576,6 +55551,18 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/service/chapel)
+"ndZ" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/water_sensor,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/station/commons/fitness/recreation/entertainment)
 "nej" = (
 /mob/living/basic/slime,
 /obj/machinery/light/directional/north,
@@ -56390,7 +56377,7 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "nmW" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
@@ -59066,7 +59053,7 @@
 /turf/open/floor/plating/reinforced,
 /area/station/medical/abandoned)
 "nWF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/door/window/brigdoor/right/directional/west{
 	name = "Warden's Desk";
@@ -59423,7 +59410,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "obm" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
@@ -60488,7 +60475,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/machinery/duct/supply,
 /obj/machinery/duct/waste,
 /obj/structure/cable,
@@ -62944,7 +62931,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/station/security/medical)
@@ -63503,6 +63490,7 @@
 /obj/item/stack/tile/iron/base,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/water_sensor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "oZG" = (
@@ -64000,7 +63988,7 @@
 /turf/open/floor/stone,
 /area/station/security/prison/garden)
 "pgj" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/east{
 	req_access = list("cargo")
@@ -64837,7 +64825,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/machinery/duct/supply,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
@@ -72829,7 +72817,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating_new,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/machinery/duct/supply,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
@@ -74829,7 +74817,7 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/medical/storage)
 "rHr" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
 /obj/item/pen,
@@ -74856,6 +74844,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/water_sensor,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/miningdock)
 "rHt" = (
@@ -75382,7 +75371,7 @@
 /turf/open/floor/iron/herringbone,
 /area/station/science/ordnance)
 "rNm" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor/heavy,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
@@ -75786,7 +75775,7 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "rSn" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
@@ -76024,7 +76013,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating_new,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/smooth_large,
 /area/station/service/kitchen)
@@ -76182,7 +76171,7 @@
 /turf/open/floor/iron/diagonal,
 /area/station/command/heads_quarters/captain)
 "rWT" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
@@ -76716,7 +76705,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "sev" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
@@ -78626,7 +78615,7 @@
 /turf/open/floor/wood,
 /area/station/cargo/storage)
 "sEW" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/open/floor/plating,
 /area/station/medical/chem_storage)
@@ -79804,7 +79793,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/iron/smooth_large,
 /area/station/service/theater)
@@ -80854,7 +80843,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "tgD" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/north{
 	name = "Pharmacy Desk";
@@ -81133,7 +81122,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/firedoor/water_sensor/heavy,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/atmos)
 "tjO" = (
@@ -84860,7 +84849,7 @@
 	dir = 8
 	},
 /obj/machinery/vending/clothing,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /turf/open/floor/iron/smooth_large,
 /area/station/service/theater)
 "ufG" = (
@@ -85789,7 +85778,7 @@
 /area/station/security/medical)
 "urW" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/flash/handheld,
 /obj/machinery/door/window/brigdoor/right/directional/east{
@@ -87733,7 +87722,7 @@
 /turf/open/floor/plating/elevatorshaft,
 /area/station/engineering/atmos)
 "uRo" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
@@ -88766,7 +88755,7 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/medical/morgue)
 "veT" = (
-/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/firedoor/water_sensor/heavy,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
@@ -89064,7 +89053,7 @@
 /turf/open/floor/iron/herringbone,
 /area/station/cargo/storage)
 "viY" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
@@ -93060,7 +93049,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/machinery/duct/supply,
 /obj/machinery/duct/waste,
 /turf/open/floor/iron/smooth_large,
@@ -95116,7 +95105,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/machinery/duct/supply,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -96641,7 +96630,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/aft)
 "wVO" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/structure/table_frame,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
@@ -97282,7 +97271,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "xdX" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
@@ -99837,7 +99826,7 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/station/engineering/atmospherics_engine)
 "xIO" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
@@ -100085,7 +100074,7 @@
 /turf/closed/wall,
 /area/station/security/medical)
 "xLM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/door/window/brigdoor/right/directional/north{
 	name = "Security Desk";
@@ -101327,7 +101316,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating_new,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/machinery/duct/supply,
 /obj/machinery/duct/waste,
 /turf/open/floor/iron/smooth_large,
@@ -101869,7 +101858,7 @@
 /turf/open/floor/iron/diagonal,
 /area/station/command/heads_quarters/ce)
 "yjk" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/water_sensor,
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/south{
 	name = "Pharmacy Desk";
@@ -102105,7 +102094,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/firedoor/water_sensor/heavy,
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/atmos)
@@ -144372,7 +144361,7 @@ qHG
 rZG
 vhq
 hgy
-lJW
+cPN
 aIy
 gub
 tOR
@@ -144629,7 +144618,7 @@ lKX
 cxF
 bDw
 yag
-fiU
+aOR
 ygU
 cMk
 esb
@@ -144886,7 +144875,7 @@ mKQ
 kFI
 xbJ
 ljf
-cCB
+fIj
 lVE
 uNn
 pcD
@@ -145394,7 +145383,7 @@ eNd
 xjE
 dcs
 dNT
-lJW
+cPN
 pKl
 blr
 iwj
@@ -145651,7 +145640,7 @@ xYN
 lHC
 lHC
 qiy
-fiU
+aOR
 gtu
 ePE
 vll
@@ -145908,7 +145897,7 @@ xzd
 usa
 kqr
 nhv
-cCB
+fIj
 fWp
 xfh
 sEU
@@ -199650,7 +199639,7 @@ eDu
 eDu
 srQ
 kZk
-oks
+ndZ
 cww
 srQ
 oac
@@ -201709,7 +201698,7 @@ oac
 srQ
 cww
 kZk
-oks
+ndZ
 rur
 rur
 auD

--- a/local/code/game/machinery/doors/firedoor.dm
+++ b/local/code/game/machinery/doors/firedoor.dm
@@ -74,3 +74,12 @@
 /obj/machinery/door/firedoor/water_sensor
 	name = "environmental shutter"
 	water_sensor = TRUE
+
+/obj/machinery/door/firedoor/water_sensor/heavy
+	name = "heavy environmental shutter"
+	desc = /obj/machinery/door/firedoor/heavy::desc
+	icon = /obj/machinery/door/firedoor/heavy::icon
+	glass = /obj/machinery/door/firedoor/heavy::glass
+	explosion_block = /obj/machinery/door/firedoor/heavy::explosion_block
+	assemblytype = /obj/machinery/door/firedoor/heavy::assemblytype // This should probably be changed for this and parent; but it's not a big enough issue atm.
+	max_integrity = /obj/machinery/door/firedoor/heavy::max_integrity


### PR DESCRIPTION
:cl:
balance: It should be significantly harder for Greytide to flood the entire first deck of Sigma Octantis.
/:cl:
