### PR TITLE
Sigma Octantis - Library Scanner; Air Alarms

### DIFF
--- a/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
+++ b/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
@@ -1281,6 +1281,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "apq" = (
@@ -25896,6 +25897,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname/directional/north,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark/side{
 	dir = 9
 	},
@@ -31203,6 +31205,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/item/storage/fancy/candle_box,
 /turf/open/floor/wood/tile,
 /area/station/service/library)
 "hiQ" = (
@@ -47597,6 +47600,7 @@
 	},
 /obj/effect/landmark/start/assistant,
 /obj/machinery/camera/autoname/directional/east,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/secondary/exit/departure_lounge)
 "lhi" = (
@@ -83738,6 +83742,14 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/cmo)
+"tPO" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/textured_large,
+/area/station/service/hydroponics)
 "tPS" = (
 /turf/closed/wall,
 /area/station/security/courtroom)
@@ -84408,7 +84420,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
-/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/checker,
 /area/station/service/cafeteria)
 "uar" = (
@@ -86686,8 +86698,7 @@
 	},
 /area/station/commons/fitness/recreation)
 "uCn" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/candle_box,
+/obj/machinery/libraryscanner,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -201925,7 +201936,7 @@ lUy
 lUy
 taB
 tpN
-mfB
+tPO
 lUy
 pzJ
 bcC


### PR DESCRIPTION
:cl:
fix: Following the mysterious lack of smut in recent months, an internal audit has revealed that a Jane Doe has been stealing each provised Library Scanner for Sigma Octantis. This has been rectified.
fix: Hey did you guys even notice that I put down more entertainment monitors instead of air alarms in the cafeteria and departures on Sigma like an idiot? That's fixed.
/:cl:
