### PR TITLE
Backports NS Leash Refactor; SR OOC Escape

### DIFF
--- a/local/code/modules/lewd/lewd_items/leash.dm
+++ b/local/code/modules/lewd/lewd_items/leash.dm
@@ -1,18 +1,19 @@
 /obj/item/clothing/erp_leash
 	name = "leash"
-	desc = "A guiding hand's best friend; in a sleek, semi-elastic package. Can either clip to a collar or be affixed to the neck on it's own."
-	icon = 'local/icons/lewd/obj/lewd_clothing/lewd_belts.dmi'
-	worn_icon = 'local/icons/lewd/mob/lewd_clothing/lewd_belts.dmi'
+	desc = "A guiding hand's best friend; in a sleek, semi-elastic package. Can either clip to a collar or be affixed to the neck on its own."
+	icon = 'modular_nova/modules/modular_items/lewd_items/icons/obj/lewd_clothing/lewd_belts.dmi'
+	worn_icon = 'modular_nova/modules/modular_items/lewd_items/icons/mob/lewd_clothing/lewd_belts.dmi'
 	icon_state = "neckleash_pink"
 	equip_sound = 'sound/items/equip/toolbelt_equip.ogg'
 	drop_sound = 'sound/items/handling/toolbelt_drop.ogg'
 	slot_flags = ITEM_SLOT_BELT
-	/// Who's this attached to?
-	var/mob/living/currently_leashed
+	breakouttime = 3 SECONDS
+	/// Weakref to the leash component we're using, if it exists.
+	var/datum/weakref/our_leash_component
 
 	unique_reskin = list(
 		"Pink" = "neckleash_pink",
-		"Teal" = "neckleash_teal"
+		"Teal" = "neckleash_teal",
 	)
 
 	COOLDOWN_DECLARE(tug_cd)
@@ -21,17 +22,15 @@
 
 /// Checks; leashing start
 /obj/item/clothing/erp_leash/attack(mob/living/carbon/human/to_be_leashed, mob/living/user, params)
-	/// Are they already leashed by another leash? If so; don't go further.
-	for(var/datum/component/leash/leash_component in to_be_leashed.GetComponents(/datum/component/leash))
-		if(leash_component.owner != src)
-			to_chat(user, span_danger("There's a leash attached to [to_be_leashed] already!"))
+	var/datum/component/leash/erp/the_leash_component = our_leash_component?.resolve()
+	if(the_leash_component)
+		if(the_leash_component.parent == to_be_leashed) // We're hooked to them; and we have a component. Get 'em out!
+			remove_leash(to_be_leashed)
 			return
-	/// Do we have the target already leashed? If so; proceed to remove the leash.
-	if(to_be_leashed == currently_leashed)
-		remove_leash(currently_leashed)
-		return
-	/// Check if we even CAN leash someone / if we already have someone leashed / if someone is leashing themselves. If so; prevent it.
-	if(!istype(to_be_leashed) || currently_leashed != null || user == to_be_leashed)
+	else
+		our_leash_component = null
+	/// Check if we even CAN leash someone / if someone is leashing themselves. If so; prevent it.
+	if(!istype(to_be_leashed) || user == to_be_leashed)
 		return
 	/// Check their ERP prefs; if they don't allow sextoys: BTFO
 	if(!to_be_leashed.check_erp_prefs(/datum/preference/toggle/erp/sex_toy, user, src))
@@ -43,45 +42,94 @@
 				span_hear("You hear a light click as pressure builds in the air around your neck."))
 	if(!do_after(user, 2 SECONDS, to_be_leashed))
 		return
-	currently_leashed = to_be_leashed
-	create_leash(currently_leashed)
-	currently_leashed.balloon_alert(user, "leashed")
-
-/obj/item/clothing/erp_leash/attack_self(mob/user, modifiers)
-	. = ..()
-	if(!COOLDOWN_FINISHED(src, tug_cd))
-		return
-	if(istype(currently_leashed, /mob/living))
-		var/mob/living/yoinked = currently_leashed
-		yoinked.Move(get_step_towards(yoinked,user))
-		yoinked.adjustStaminaLoss(10)
-		yoinked.visible_message(span_warning("[yoinked] is pulled in as [user] tugs the [src]!"),\
-				span_userdanger("[user] suddenly tugs the [src], pulling you closer!"),\
-				span_userdanger("A sudden tug against your neck pulls you ahead!"))
-	COOLDOWN_START(src, tug_cd, 1 SECONDS)
+	create_leash(user, to_be_leashed)
 
 /// Leash Initialization
-/obj/item/clothing/erp_leash/proc/create_leash(mob/ouppy)
+/obj/item/clothing/erp_leash/proc/create_leash(mob/user, mob/ouppy)
 	if(!istype(ouppy))
 		return
-	ouppy.AddComponent(/datum/component/leash, src, 2)
 
-/// Leash Removal
-/obj/item/clothing/erp_leash/proc/remove_leash(mob/free_bird)
-	if(!istype(free_bird))
+	ouppy.AddComponent(/datum/component/leash/erp, src, 2)
+	if(our_leash_component.resolve()) // The component will immediately delete itself if there's an existing one; this sanity checks for feedback on if it failed.
+		ouppy.balloon_alert(user, "leashed!")
 		return
-	free_bird.balloon_alert_to_viewers("unhooked")
-	for(var/datum/component/leash/leash_component in free_bird.GetComponents(/datum/component/leash))
-		if(leash_component.owner == src) // We don't want to remove any other possible leash components - not that they'd play nice regardless.
-			qdel(leash_component)
-		currently_leashed = null
+	else to_chat(user, span_danger("There's a leash attached to [ouppy] already."))
 
-/// Dropped it
-/obj/item/clothing/erp_leash/dropped(mob/user, silent)
-	. = ..()
-	remove_leash(currently_leashed)
+/// Leash removal
+/obj/item/clothing/erp_leash/proc/remove_leash(mob/free_bird)
+	free_bird?.balloon_alert_to_viewers("unhooked")
+	qdel(our_leash_component.resolve())
 
-/// Clean up when destroyed
-/obj/item/clothing/erp_leash/Destroy()
-	remove_leash(currently_leashed)
+/*
+	Leash Component
+*/
+
+/datum/component/leash/erp
+	dupe_mode = COMPONENT_DUPE_UNIQUE
+	dupe_type = /datum/component/leash
+
+// 'owner' refers the leash item, while 'parent' refers to the one it's affixed to.
+/datum/component/leash/erp/RegisterWithParent()
 	. = ..()
+	// Owner Signals
+	RegisterSignal(owner, COMSIG_ITEM_ATTACK_SELF, PROC_REF(on_item_attack_self))
+	RegisterSignal(owner, COMSIG_ITEM_DROPPED, PROC_REF(on_item_dropped))
+	// Parent Signals
+	RegisterSignal(parent, COMSIG_LIVING_RESIST, PROC_REF(on_parent_resist))
+	if(istype(owner, /obj/item/clothing/erp_leash))
+		var/obj/item/clothing/erp_leash/our_leash = owner
+		our_leash.our_leash_component = WEAKREF(src)
+
+/datum/component/leash/erp/UnregisterFromParent()
+	if(owner) // Destroy() sets owner to null
+		UnregisterSignal(owner, list(COMSIG_ITEM_ATTACK_SELF, COMSIG_ITEM_DROPPED))
+		UnregisterSignal(parent, COMSIG_LIVING_RESIST)
+	return ..()
+
+/datum/component/leash/erp/Destroy() // Have to do this here too
+	UnregisterSignal(owner, list(COMSIG_ITEM_ATTACK_SELF, COMSIG_ITEM_DROPPED))
+	if(istype(owner, /obj/item/clothing/erp_leash))
+		var/obj/item/clothing/erp_leash/our_leash = owner
+		our_leash.our_leash_component = null
+	return ..()
+
+
+/datum/component/leash/erp/proc/on_item_attack_self(datum/source, mob/user)
+	SIGNAL_HANDLER
+
+	if(istype(source, /obj/item/clothing/erp_leash))
+		var/obj/item/clothing/erp_leash/leash_hookin = source
+		if(!COOLDOWN_FINISHED(leash_hookin, tug_cd))
+			return
+		if(istype(parent, /mob/living))
+			var/mob/living/yoinked = parent
+			yoinked.Move(get_step_towards(yoinked,user))
+			yoinked.adjustStaminaLoss(10)
+			yoinked.visible_message(span_warning("[yoinked] is pulled in as [user] tugs the [source]!"),\
+					span_userdanger("[user] suddenly tugs the [source], pulling you closer!"),\
+					span_userdanger("A sudden tug against your neck pulls you ahead!"))
+			COOLDOWN_START(leash_hookin, tug_cd, 1 SECONDS)
+
+/datum/component/leash/erp/proc/on_item_dropped(datum/source, mob/user)
+	SIGNAL_HANDLER
+
+	if(istype(parent, /mob))
+		var/mob/our_parent = parent
+		our_parent.balloon_alert_to_viewers("unhooked")
+	qdel(src)
+
+/datum/component/leash/erp/proc/on_parent_resist(datum/source, mob/user)
+	SIGNAL_HANDLER
+	INVOKE_ASYNC(src, PROC_REF(do_resist))
+
+/datum/component/leash/erp/proc/do_resist(datum/source, mob/user)
+	if(istype(parent, /mob) && istype(owner,/obj/item))
+		var/mob/our_parent = parent
+		var/obj/item/our_owner = owner
+		our_parent.visible_message(span_warning("[our_parent] attempts to unhook [our_parent.p_them()]self from the leash!"), \
+			span_userdanger("You start to unhook yourself from the leash..."), \
+			span_userdanger("You fumble in the dark, looking to unhook the leash..."))
+		if(do_after(our_parent, our_owner.breakouttime, target = our_parent))
+			to_chat(our_parent, span_notice("You unhook yourself from the leash."))
+			qdel(src)
+	else qdel(src) // If they're not an item; something is very wrong - qdel anyways without the breakout time.

--- a/local/code/modules/lewd/lewd_items/leash.dm
+++ b/local/code/modules/lewd/lewd_items/leash.dm
@@ -1,8 +1,8 @@
 /obj/item/clothing/erp_leash
 	name = "leash"
 	desc = "A guiding hand's best friend; in a sleek, semi-elastic package. Can either clip to a collar or be affixed to the neck on its own."
-	icon = 'modular_nova/modules/modular_items/lewd_items/icons/obj/lewd_clothing/lewd_belts.dmi'
-	worn_icon = 'modular_nova/modules/modular_items/lewd_items/icons/mob/lewd_clothing/lewd_belts.dmi'
+	icon = 'local/icons/lewd/obj/lewd_clothing/lewd_belts.dmi'
+	worn_icon = 'local/icons/lewd/mob/lewd_clothing/lewd_belts.dmi'
 	icon_state = "neckleash_pink"
 	equip_sound = 'sound/items/equip/toolbelt_equip.ogg'
 	drop_sound = 'sound/items/handling/toolbelt_drop.ogg'

--- a/local/code/modules/lewd/verbs.dm
+++ b/local/code/modules/lewd/verbs.dm
@@ -16,3 +16,23 @@
 	. = ..()
 	if(CONFIG_GET(flag/disable_erp_preferences))
 		verbs -= /mob/living/carbon/human/verb/climax_verb
+
+/mob/living/carbon/human/verb/safeword()
+	set name = "Remove Lewd Items"
+	set category = "OOC"
+	set desc = "Removes any and all lewd items from you."
+
+	log_message("[key_name(src)] used the Remove Lewd Items verb.", LOG_ATTACK)
+	for(var/obj/item/equipped_item in get_equipped_items())
+		if(!(equipped_item.type in GLOB.pref_checked_clothes))
+			continue
+
+		log_message("[equipped_item] was removed from [key_name(src)].", LOG_ATTACK)
+		dropItemToGround(equipped_item, TRUE)
+
+	// Leashes are treated a smidge different than the rest of the clothing; and need their own handling here.
+	var/leash_check = src?.GetComponent(/datum/component/leash/erp)
+	if(leash_check)
+		qdel(leash_check)
+
+	return TRUE


### PR DESCRIPTION
## About The Pull Request
https://github.com/NovaSector/NovaSector/pull/2306
https://github.com/Skyrat-SS13/Skyrat-tg/pull/21287
## Why It's Good For The Game
Latter is good for player safety; former is good for code sanity. And the new bells and whistles.
## Changelog
:cl: softcerv for Skyrat, vinylspiders and unit0016 for Nova Sector
qol: adds a safeword verb under the ooc tab that can be used to remove all equipped organic interface items from someone.
code: Leashes have been heavily refactored and now come with additional features.
/:cl:
