### PR TITLE
Adds myself as codeowner of /_maps/; fixes alphabetization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,8 @@
 
 # MAINTAINERS
 /.github/ @lessthnthree
-/packages/ @lessthnthree
 /config/ @lessthnthree
+/packages/ @lessthnthree
 /tgui/ @lessthnthree
+
+/_maps/ @unit0016


### PR DESCRIPTION
No player-facing changes. I'm targeting `/_maps/` rather than `/_maps/effigy/` specifically to account for repaths / new stuff upstream I'd have to take into consideration.