### PR TITLE
Sigma Octantis - Engineering SMES Fix

### DIFF
--- a/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
+++ b/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
@@ -3182,6 +3182,7 @@
 	},
 /obj/machinery/modular_computer/preset/engineering,
 /obj/machinery/camera/autoname/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "aLi" = (
@@ -11543,7 +11544,8 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 4
 	},
-/obj/machinery/computer/station_alert,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "cIw" = (
@@ -28356,6 +28358,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "gAu" = (
@@ -82627,8 +82630,9 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "tCV" = (


### PR DESCRIPTION
:cl:
fix: The engineering console in the SMES room on Sigma Octantis is no longer... scuffed.
/:cl:
