### PR TITLE
Backports, or [REDACTED]?

### DIFF
--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -1460,6 +1460,22 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
+"aGD" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/obj/structure/fence/end{
+	dir = 1
+	},
+/obj/structure/railing/corner/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/taeloth)
 "aGP" = (
 /obj/structure/cable,
 /turf/open/floor/iron/chapel{
@@ -2016,6 +2032,15 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/warehouse)
+"aVa" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/taeloth)
 "aVc" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 4
@@ -4038,6 +4063,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"bHE" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/obj/structure/fence/end,
+/obj/structure/railing/corner/end/flip,
+/turf/open/floor/plating,
+/area/taeloth)
 "bHM" = (
 /obj/structure/closet/secure_closet/psychology,
 /obj/structure/cable,
@@ -4542,6 +4579,12 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/machinery/requests_console/auto_name/directional/north,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/ore_update,
+/obj/effect/mapping_helpers/requests_console/supplies,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "bRN" = (
@@ -7534,6 +7577,20 @@
 	},
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"dcC" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/marker_beacon/bronze,
+/turf/open/floor/plating,
+/area/taeloth)
 "dcE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -12230,9 +12287,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/range)
 "eUJ" = (
-/obj/structure/railing/corner/end{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 8
 	},
@@ -13113,6 +13167,18 @@
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/theater)
+"fmv" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/obj/structure/fence/end,
+/obj/structure/railing/corner/end,
+/turf/open/floor/plating,
+/area/taeloth)
 "fmw" = (
 /obj/structure/flora/rock/style_4,
 /turf/open/misc/grass/jungle,
@@ -13345,6 +13411,16 @@
 /area/station/engineering/atmos/hfr_room)
 "fqS" = (
 /obj/machinery/firealarm/directional/north,
+/obj/structure/window/spawner/directional/west,
+/obj/structure/window/spawner/directional/south,
+/obj/structure/table,
+/obj/item/storage/toolbox/fishing{
+	pixel_y = 12
+	},
+/obj/item/storage/toolbox/fishing{
+	pixel_y = 6
+	},
+/obj/item/storage/toolbox/fishing,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/medical/medbay/central)
 "frg" = (
@@ -17310,7 +17386,7 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "gYU" = (
-/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver{
+/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver/longrange{
 	pixel_y = -24
 	},
 /obj/machinery/computer/security/telescreen/ordnance{
@@ -18670,6 +18746,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/command/nuke_storage)
 "hCd" = (
@@ -20290,6 +20367,20 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark/small,
 /area/station/security/checkpoint/escape)
+"imE" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/obj/structure/fence/end{
+	dir = 8
+	},
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/taeloth)
 "inj" = (
 /obj/machinery/door/window/left/directional/north{
 	name = "Crate Return Access";
@@ -22324,6 +22415,20 @@
 "jex" = (
 /turf/open/misc/dirt/jungle,
 /area/station/security/prison/garden)
+"jeF" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/obj/structure/fence/end{
+	dir = 4
+	},
+/obj/structure/railing/corner/end/flip{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/taeloth)
 "jeG" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/machinery/conveyor{
@@ -26531,6 +26636,16 @@
 /obj/effect/turf_decal/siding/dark_red,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/checkpoint/escape)
+"kNB" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/obj/structure/railing,
+/obj/structure/marker_beacon/bronze,
+/turf/open/floor/plating,
+/area/taeloth)
 "kND" = (
 /obj/structure/disposalpipe/sorting/mail/flip,
 /obj/effect/mapping_helpers/mail_sorting/security/hos_office,
@@ -33600,6 +33715,19 @@
 	dir = 10
 	},
 /area/station/science)
+"nKu" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/taeloth)
 "nKz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -37665,13 +37793,24 @@
 /turf/open/floor/iron/dark/small,
 /area/station/service/theater)
 "pvf" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 8
 	},
 /obj/machinery/light/directional/north,
+/obj/structure/window/spawner/directional/east,
+/obj/structure/window/spawner/directional/south,
+/obj/structure/table,
+/obj/item/fishing_hook/rescue{
+	pixel_y = 4;
+	pixel_x = 6
+	},
+/obj/item/fishing_hook/rescue{
+	pixel_x = 6
+	},
+/obj/item/fishing_hook/rescue{
+	pixel_x = 6;
+	pixel_y = -2
+	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "pvt" = (
@@ -41224,6 +41363,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"qPc" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/obj/structure/fence/end{
+	dir = 1
+	},
+/obj/structure/railing/corner/end/flip{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/taeloth)
 "qPh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/mapping_helpers/broken_floor,
@@ -42988,6 +43143,19 @@
 /turf/open/floor/plating/reinforced,
 /area/station/maintenance/department/medical)
 "rAv" = (
+/obj/structure/table,
+/obj/machinery/door/window/left/directional/south{
+	req_access = list("medical");
+	name = "Extended Rescue Supplies"
+	},
+/obj/item/fishing_line/bouncy{
+	pixel_y = 11;
+	pixel_x = 6
+	},
+/obj/item/fishing_line/reinforced{
+	pixel_y = 5;
+	pixel_x = -4
+	},
 /turf/open/floor/catwalk_floor/iron,
 /area/station/medical/medbay/central)
 "rAK" = (
@@ -48083,6 +48251,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "tDL" = (
@@ -53311,6 +53480,20 @@
 "vHJ" = (
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
+"vIl" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/marker_beacon/bronze,
+/turf/open/floor/plating,
+/area/taeloth)
 "vII" = (
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 5
@@ -54234,6 +54417,12 @@
 	dir = 10
 	},
 /obj/structure/bed/dogbed,
+/obj/machinery/requests_console/auto_name/directional/north,
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/ore_update,
+/obj/effect/mapping_helpers/requests_console/supplies,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "waw" = (
@@ -81909,7 +82098,7 @@ mMy
 xiH
 uuj
 eXI
-peI
+lZm
 ktx
 guW
 guW
@@ -82166,7 +82355,7 @@ bbg
 tTC
 tTC
 agz
-peI
+lZm
 smH
 dbC
 ibt
@@ -82423,7 +82612,7 @@ kRN
 mVB
 fBu
 rFy
-peI
+lZm
 izM
 bac
 sqW
@@ -82680,7 +82869,7 @@ ugB
 prS
 fXr
 xpK
-peI
+lZm
 sEK
 bPW
 xib
@@ -90421,11 +90610,11 @@ vMS
 vMS
 xEZ
 mhb
-jpx
-jpx
-jpx
-jpx
-jpx
+bHE
+dcC
+hJl
+dcC
+aGD
 mhb
 xEZ
 sAb
@@ -90677,7 +90866,7 @@ vMS
 vMS
 vMS
 sAb
-tNM
+xyM
 iYL
 iYL
 iYL
@@ -90934,7 +91123,7 @@ vMS
 vMS
 vMS
 sAb
-tNM
+hyE
 iYL
 iYL
 iYL
@@ -91191,7 +91380,7 @@ vMS
 vMS
 vMS
 sAb
-tNM
+imE
 iYL
 iYL
 iYL
@@ -91448,7 +91637,7 @@ vMS
 vMS
 jpo
 sAb
-tNM
+kNB
 iYL
 iYL
 iYL
@@ -91705,7 +91894,7 @@ vMS
 vMS
 vSj
 sAb
-tNM
+aVa
 iYL
 iYL
 iYL
@@ -91962,7 +92151,7 @@ vMS
 vMS
 vSj
 sAb
-tNM
+kNB
 iYL
 iYL
 iYL
@@ -92219,7 +92408,7 @@ vMS
 vSj
 sAb
 sAb
-tNM
+jeF
 iYL
 iYL
 iYL
@@ -92476,7 +92665,7 @@ vMS
 vSj
 wvK
 sAb
-tNM
+hyE
 iYL
 iYL
 iYL
@@ -92733,7 +92922,7 @@ vMS
 vSj
 sAb
 sAb
-tNM
+xyM
 iYL
 iYL
 iFf
@@ -92991,11 +93180,11 @@ sAb
 sAb
 xEZ
 mhb
-jpx
-jpx
-jpx
-jpx
-jpx
+fmv
+vIl
+nKu
+vIl
+qPc
 mhb
 xEZ
 sAb

--- a/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
+++ b/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
@@ -54769,7 +54769,6 @@
 /turf/open/floor/iron/kitchen,
 /area/station/commons/dorms/apartment1)
 "mSO" = (
-/obj/structure/rack,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -61262,6 +61261,9 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver/longrange{
+	pixel_y = 26
+	},
 /turf/open/floor/iron/white/diagonal,
 /area/station/science/ordnance/testlab)
 "owq" = (
@@ -87135,6 +87137,9 @@
 "uFF" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/directional/south,
+/obj/machinery/computer/order_console/cook{
+	dir = 1
+	},
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "uFR" = (
@@ -88173,10 +88178,6 @@
 	},
 /obj/machinery/door/poddoor{
 	id = "cargo_cargoload";
-	name = "Supply Dock Loading Door"
-	},
-/obj/machinery/door/poddoor{
-	id = "QMLoaddoor2";
 	name = "Supply Dock Loading Door"
 	},
 /turf/open/floor/plating,
@@ -100427,6 +100428,12 @@
 /area/station/engineering/atmos/upper)
 "xMW" = (
 /obj/machinery/computer/apc_control,
+/obj/machinery/requests_console/auto_name/directional/north,
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/ore_update,
+/obj/effect/mapping_helpers/requests_console/supplies,
 /turf/open/floor/glass/reinforced,
 /area/station/command/heads_quarters/ce)
 "xNg" = (


### PR DESCRIPTION
This doesn't backport the Sigma stopgap fix. I'm going to atomize that into it's own PR and TM it for Saturday.

:cl:
fix: Head of staff offices now actually have request consoles on all of our maps. Oops.
add: Rimpoint's arrivals shuttle is now railed off after a series of incidents involving a splat sound effect.
fix: Rimpoint's disposals now goes off into the lava pit as intended.
add: Rimpoint now has a dedicated set of fishing gear for medical; what with all the chasms about.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
