### PR TITLE
Randomizable Blooper Support

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -56,9 +56,9 @@
 	// EffigyEdit Add - Vocal Bloopers
 	for(var/blooper_path in subtypesof(/datum/blooper))
 		var/datum/blooper/bloop = new blooper_path()
-		GLOB.blooper_list[bloop.id] = blooper_path
+		GLOB.blooper_list[bloop.id] = bloop
 		if(bloop.allow_random)
-			GLOB.blooper_random_list[bloop.id] = blooper_path
+			GLOB.blooper_random_list[bloop.id] = bloop
 	// EffigyEdit Add End
 
 /// Inits GLOB.surgeries

--- a/local/code/modules/bloopers/atoms_movable.dm
+++ b/local/code/modules/bloopers/atoms_movable.dm
@@ -2,6 +2,7 @@
 	// Text-to-blooper sounds
 	// yes. all atoms can have a say.
 	var/sound/blooper
+	var/list/blooper_list
 	var/blooper_id
 	var/blooper_pitch = 1
 	var/blooper_pitch_range = 0.2 //Actual pitch is (pitch - (blooper_pitch_range*0.5)) to (pitch + (blooper_pitch_range*0.5))
@@ -15,7 +16,12 @@
 	var/datum/blooper/bloop = GLOB.blooper_list[id]
 	if(!bloop)
 		return FALSE
-	blooper = sound(initial(bloop.soundpath))
+	blooper = sound(bloop.soundpath)
+	var/list/blooplist = bloop.soundpath_list
+	if(blooplist)
+		blooper_list = list()
+		for(var/a_blooper in blooplist)
+			blooper_list += sound(a_blooper)
 	blooper_id = id
 	return blooper
 
@@ -29,8 +35,11 @@
 			return
 	volume = min(volume, 100)
 	var/turf/local_turf = get_turf(src)
+	var/sound/blooper_pick = blooper
+	if(length(blooper_list) > 0)
+		blooper_pick = pick(blooper_list)
 	for(var/mob/target_mob in listeners)
-		target_mob.playsound_local(local_turf, vol = volume, vary = TRUE, frequency = pitch, max_distance = distance, falloff_distance = 0, falloff_exponent = BLOOPER_SOUND_FALLOFF_EXPONENT, sound_to_use = blooper, distance_multiplier = 1)
+		target_mob.playsound_local(local_turf, vol = volume, vary = TRUE, frequency = pitch, max_distance = distance, falloff_distance = 0, falloff_exponent = BLOOPER_SOUND_FALLOFF_EXPONENT, sound_to_use = blooper_pick, distance_multiplier = 1)
 
 /atom/movable/send_speech(message, range = 7, obj/source = src, bubble_type, list/spans, datum/language/message_language, list/message_mods = list(), forced = FALSE, tts_message, list/tts_filter)
 	. = ..()

--- a/local/code/modules/bloopers/bark.dm
+++ b/local/code/modules/bloopers/bark.dm
@@ -144,6 +144,7 @@ It has also been further modified by Rashcat & other Fluffyfrontier contributors
 	var/name = "None"
 	var/id = "No Voice"
 	var/soundpath
+	var/list/soundpath_list
 
 	var/minpitch = BLOOPER_DEFAULT_MINPITCH
 	var/maxpitch = BLOOPER_DEFAULT_MAXPITCH

--- a/local/code/modules/bloopers/bark_list.dm
+++ b/local/code/modules/bloopers/bark_list.dm
@@ -167,6 +167,14 @@
 	name = "Gaster"
 	id = "gaster"
 	soundpath = 'local/sound/voice/bloopers/undertale/voice_gaster_1.ogg'
+	soundpath_list = list(
+		'local/sound/voice/bloopers/undertale/voice_gaster_1.ogg',
+		'local/sound/voice/bloopers/undertale/voice_gaster_2.ogg',
+		'local/sound/voice/bloopers/undertale/voice_gaster_3.ogg',
+		'local/sound/voice/bloopers/undertale/voice_gaster_4.ogg',
+		'local/sound/voice/bloopers/undertale/voice_gaster_5.ogg',
+		'local/sound/voice/bloopers/undertale/voice_gaster_6.ogg',
+		'local/sound/voice/bloopers/undertale/voice_gaster_7.ogg')
 	minvariance = 0
 
 /datum/blooper/mettaton


### PR DESCRIPTION
## About The Pull Request

Upgrades the voice blooper system to support randomized sound selections for certain voice types, currently demo'd via the W.D. Gaster voice now being accurate.  This should lay the groundwork for a larger expansion allowing things like the Don't Starve vocal bloops to be properly randomized per their O.G. implementation.

## Why It's Good For The Game

The single W.D. Gaster bloop on repeat hurts my all-too Undertale-fanon-fixated SOUL.  Now it doesn't.  Being able to get the Don't Starve bloops working down the line should be a nice boost, too, they're really friggen charming.

https://github.com/effigy-se/effigy-se/assets/2958111/4e0fd27a-d381-4cae-a5d1-d9614a06aea6

## Changelog
:cl:
fix: The Gaster blooper voice is now accurate!
refactor: Multi-sound blooper voices are now supported.
/:cl: