### PR TITLE
Stopgaps cargo borg icon

### DIFF
--- a/local/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/local/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -337,7 +337,7 @@
 	)
 	hat_offset = 0
 	cyborg_base_icon = "cargo"
-	model_select_icon = "cargo"
+	model_select_icon = "lost"
 	model_select_alternate_icon = 'local/icons/mob/borgs/screen_cyborg.dmi'
 	canDispose = TRUE
 	borg_skins = list(


### PR DESCRIPTION
Fixes #853 

:cl:
fix: Cargo borgs can use their modules.
/:cl:
