### PR TITLE
[MODULAR] Bodypart Layering Tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -574,7 +574,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 
 			var/datum/sprite_accessory/markings = GLOB.moth_markings_list[species_human.dna.features["moth_markings"]]
-			var/mutable_appearance/marking = mutable_appearance(layer = -BODY_LAYER, appearance_flags = KEEP_TOGETHER)
+			var/mutable_appearance/marking = mutable_appearance(layer = -(UNIFORM_LAYER + 0.01), appearance_flags = KEEP_TOGETHER)
 			if(noggin && (IS_ORGANIC_LIMB(noggin)))
 				var/mutable_appearance/markings_head_overlay = mutable_appearance(markings.icon, "[markings.icon_state]_head")
 				marking.overlays += markings_head_overlay
@@ -613,7 +613,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 				var/icon_state = underwear.icon_state
 				if(underwear.has_digitigrade && (species_human.bodyshape & BODYSHAPE_DIGITIGRADE))
 					icon_state += "_d"
-				underwear_overlay = mutable_appearance(underwear.icon, icon_state, -BODY_LAYER)
+				underwear_overlay = mutable_appearance(underwear.icon, icon_state, -(UNIFORM_LAYER + 0.01))
 				if(!underwear.use_static)
 					underwear_overlay.color = species_human.underwear_color
 				standing += underwear_overlay
@@ -625,7 +625,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 				if(species_human.dna.species.sexes && species_human.gender == FEMALE)
 					undershirt_overlay = wear_female_version(undershirt.icon_state, undershirt.icon, BODY_LAYER)
 				else
-					undershirt_overlay = mutable_appearance(undershirt.icon, undershirt.icon_state, -BODY_LAYER)
+					undershirt_overlay = mutable_appearance(undershirt.icon, undershirt.icon_state, -(UNIFORM_LAYER + 0.01))
 				if(!undershirt.use_static)
 					undershirt_overlay.color = species_human.undershirt_color
 				standing += undershirt_overlay
@@ -637,7 +637,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 				var/icon_state = socks.icon_state
 				if((species_human.bodyshape & BODYSHAPE_DIGITIGRADE))
 					icon_state += "_d"
-				socks_overlay = mutable_appearance(socks.icon, icon_state, -BODY_LAYER)
+				socks_overlay = mutable_appearance(socks.icon, icon_state, -(UNIFORM_LAYER + 0.02))
 				if(!socks.use_static)
 					socks_overlay.color = species_human.socks_color
 				standing += socks_overlay

--- a/local/code/modules/mob/dead/new_player/sprite_accessories/genitals.dm
+++ b/local/code/modules/mob/dead/new_player/sprite_accessories/genitals.dm
@@ -73,7 +73,7 @@
 	special_icon_case = TRUE
 	special_x_dimension = TRUE
 	//default_color = DEFAULT_SKIN_OR_PRIMARY //This is the price we're paying for sheaths
-	relevent_layers = list(BODY_BEHIND_LAYER, BODY_FRONT_LAYER)
+	relevent_layers = list(BODY_BEHIND_LAYER, BODY_FRONT_UNDER_CLOTHES)
 	genetic = TRUE
 	var/can_have_sheath = TRUE
 
@@ -192,7 +192,7 @@
 	key = ORGAN_SLOT_VAGINA
 	always_color_customizable = TRUE
 	default_color = "#FFCCCC"
-	relevent_layers = list(BODY_FRONT_LAYER)
+	relevent_layers = list(BODY_FRONT_UNDER_CLOTHES)
 	genetic = TRUE
 	var/alt_aroused = TRUE
 
@@ -278,7 +278,7 @@
 	key = ORGAN_SLOT_BREASTS
 	always_color_customizable = TRUE
 	default_color = DEFAULT_SKIN_OR_PRIMARY
-	relevent_layers = list(BODY_BEHIND_LAYER, BODY_FRONT_LAYER)
+	relevent_layers = list(BODY_BEHIND_LAYER, BODY_FRONT_UNDER_CLOTHES)
 	has_skintone_shading = TRUE
 	genital_location = CHEST
 	genetic = TRUE

--- a/local/code/modules/surgery/organs/genitals.dm
+++ b/local/code/modules/surgery/organs/genitals.dm
@@ -31,6 +31,7 @@
 	var/datum/bodypart_overlay/mutant/genital/our_overlay = bodypart_overlay
 
 	our_overlay.sprite_suffix = sprite_suffix
+	our_overlay.owner = owner
 
 
 /obj/item/organ/external/genital/proc/get_description_string(datum/sprite_accessory/genital/gas)
@@ -70,6 +71,7 @@
 	var/datum/bodypart_overlay/mutant/genital/our_overlay = bodypart_overlay
 
 	our_overlay.color_source = uses_skin_color ? ORGAN_COLOR_INHERIT : ORGAN_COLOR_OVERRIDE
+	our_overlay.owner = owner
 
 /// for specific build_from_dna behavior that also checks the genital accessory.
 /obj/item/organ/external/genital/proc/build_from_accessory(datum/sprite_accessory/genital/accessory, datum/dna/DNA)
@@ -97,10 +99,12 @@
 
 
 /datum/bodypart_overlay/mutant/genital
-	layers = EXTERNAL_FRONT
+	layers = EXTERNAL_FRONT_UNDER_CLOTHES
 	color_source = ORGAN_COLOR_OVERRIDE
 	/// The suffix appended to the feature_key for the overlays.
 	var/sprite_suffix
+	/// Owning human.  Used to adjust layers depending on underwear
+	var/mob/living/carbon/human/owner
 
 /datum/bodypart_overlay/mutant/genital/override_color(rgb_value)
 	return draw_color
@@ -133,6 +137,25 @@
 
 	return sprite_datum.color_layer_names
 
+/datum/bodypart_overlay/mutant/genital/mutant_bodyparts_layertext(layer)
+	if(layer == -(UNIFORM_LAYER - 0.01) || layer == -(UNIFORM_LAYER + 0.03))
+		return "FRONT"
+	else
+		return ..()
+
+/// Return TRUE if this should overlay below underwear, otherwise it'll layer above it and the uniform.
+/datum/bodypart_overlay/mutant/genital/proc/underwear_check()
+	return TRUE
+
+/datum/bodypart_overlay/mutant/genital/bitflag_to_layer(layer)
+	if(EXTERNAL_FRONT_UNDER_CLOTHES)
+		if(underwear_check() == FALSE)
+			return -(UNIFORM_LAYER - 0.01)
+		else
+			return -(UNIFORM_LAYER + 0.03)
+	else
+		return ..()
+
 
 /obj/item/organ/external/genital/penis
 	name = "penis"
@@ -150,7 +173,16 @@
 
 /datum/bodypart_overlay/mutant/genital/penis
 	feature_key = ORGAN_SLOT_PENIS
-	layers = EXTERNAL_FRONT | EXTERNAL_BEHIND
+	layers = EXTERNAL_FRONT_UNDER_CLOTHES | EXTERNAL_BEHIND
+
+/datum/bodypart_overlay/mutant/genital/penis/underwear_check()
+	if(!istype(owner))
+		return TRUE
+	else
+		if(owner.underwear_visibility & UNDERWEAR_HIDE_UNDIES)
+			return FALSE
+		else
+			return TRUE
 
 
 /obj/item/organ/external/genital/penis/get_description_string(datum/sprite_accessory/genital/gas)
@@ -322,7 +354,16 @@
 
 /datum/bodypart_overlay/mutant/genital/vagina
 	feature_key = ORGAN_SLOT_VAGINA
-	layers = EXTERNAL_FRONT
+	layers = EXTERNAL_FRONT_UNDER_CLOTHES | EXTERNAL_BEHIND
+
+/datum/bodypart_overlay/mutant/genital/penis/underwear_check()
+	if(!istype(owner))
+		return TRUE
+	else
+		if(owner.underwear_visibility & UNDERWEAR_HIDE_UNDIES)
+			return FALSE
+		else
+			return TRUE
 
 /obj/item/organ/external/genital/vagina/get_description_string(datum/sprite_accessory/genital/gas)
 	var/returned_string = "You see a [lowertext(genital_name)] vagina."
@@ -375,6 +416,16 @@
 	feature_key = ORGAN_SLOT_WOMB
 	layers = NONE
 
+/// Maybe a little bit unnecessary since this is always hidden, but completeness demands such
+/datum/bodypart_overlay/mutant/genital/womb/underwear_check()
+	if(!istype(owner))
+		return TRUE
+	else
+		if(owner.underwear_visibility & UNDERWEAR_HIDE_SHIRT)
+			return FALSE
+		else
+			return TRUE
+
 /datum/bodypart_overlay/mutant/genital/womb/get_global_feature_list()
 	return GLOB.sprite_accessories[ORGAN_SLOT_WOMB]
 
@@ -395,6 +446,16 @@
 /datum/bodypart_overlay/mutant/genital/anus
 	feature_key = ORGAN_SLOT_ANUS
 	layers = NONE
+
+/// See above, here for completeness if a sprite is ever added
+/datum/bodypart_overlay/mutant/genital/anus/underwear_check()
+	if(!istype(owner))
+		return TRUE
+	else
+		if(owner.underwear_visibility & UNDERWEAR_HIDE_UNDIES)
+			return FALSE
+		else
+			return TRUE
 
 /obj/item/organ/external/genital/anus/get_description_string(datum/sprite_accessory/genital/gas)
 	var/returned_string = "You see an [lowertext(genital_name)]."
@@ -425,7 +486,16 @@
 
 /datum/bodypart_overlay/mutant/genital/breasts
 	feature_key = ORGAN_SLOT_BREASTS
-	layers = EXTERNAL_FRONT | EXTERNAL_BEHIND
+	layers = EXTERNAL_FRONT_UNDER_CLOTHES | EXTERNAL_BEHIND
+
+/datum/bodypart_overlay/mutant/genital/penis/underwear_check()
+	if(!istype(owner))
+		return TRUE
+	else
+		if(owner.underwear_visibility & UNDERWEAR_HIDE_UNDIES)
+			return FALSE
+		else
+			return TRUE
 
 /obj/item/organ/external/genital/breasts/get_description_string(datum/sprite_accessory/genital/gas)
 	var/returned_string = "You see a [lowertext(genital_name)] of breasts."


### PR DESCRIPTION
## About The Pull Request

Re-orders enterprise resource planning bodypart rendering to actually fit in underneath accessories & all clothing but undersuits, as was likely originally intended. I am open to trying to modify this code further to make layer an explicit toggle with a verb but it's gonna be Complicated(tm) to get right.

Amended to also change layers dependent on underclothes - with appropriate underclothes enabled, the layer shifts to 0.02 below undersuits (and underclothes now render at 0.01 below), allowing certain combinations on the chest to be viable. Without appropriate underclothes, they remain above the uniform layer (e.g, combo with gear harness, leg-only undersuits) as initially implemented.

## Why It's Good For The Game

Long hair over the chest, open jacket over the chest, the bespoke accessories, all of them *work now*!

## Changelog

:cl:
fix: some bodypart rendering is properly below most clothes & bespoke accessories now.
/:cl:
