### PR TITLE
[LOL] Unfucks Luna's Energy Upgrade So It Actually Works

### DIFF
--- a/local/code/modules/mapfluff/ruins/jungle_ruin_code.dm
+++ b/local/code/modules/mapfluff/ruins/jungle_ruin_code.dm
@@ -17,7 +17,9 @@
 	light_on = FALSE
 	force = 15
 	throwforce = 10
-	bare_wound_bonus = 10
+	bare_wound_bonus = 35 // If your target's unarmored; lol. Lmao
+	armour_penetration = 10 // Sharp enough to poke by default; but not exactly cleaving through any armor without the energy upgrade
+	block_chance = 20 // Definitely agile enough to block; but keep in mind it's a rapier and not a bulkier sword
 	var/list/fragments = list()
 	var/can_bloodbeam = FALSE
 

--- a/local/code/modules/mapfluff/ruins/jungle_ruin_code.dm
+++ b/local/code/modules/mapfluff/ruins/jungle_ruin_code.dm
@@ -154,12 +154,12 @@
 	update_inhand_icon(user)
 	upgrade_appliable.set_light_on(TRUE)
 	playsound(upgrade_appliable, 'sound/weapons/saberon.ogg', 35, TRUE)
-	force = /obj/item/melee/energy/sword::active_force
-	throwforce = /obj/item/melee/energy/sword::active_throwforce
-	bare_wound_bonus = /obj/item/melee/energy/sword::bare_wound_bonus
-	demolition_mod = /obj/item/melee/energy/sword::demolition_mod
-	armour_penetration = /obj/item/melee/energy/sword::armour_penetration
-	block_chance = /obj/item/melee/energy/sword::block_chance
+	upgrade_appliable.force = /obj/item/melee/energy/sword::active_force
+	upgrade_appliable.throwforce = /obj/item/melee/energy/sword::active_throwforce
+	upgrade_appliable.bare_wound_bonus = /obj/item/melee/energy/sword::bare_wound_bonus
+	upgrade_appliable.demolition_mod = /obj/item/melee/energy/sword::demolition_mod
+	upgrade_appliable.armour_penetration = /obj/item/melee/energy/sword::armour_penetration
+	upgrade_appliable.block_chance = /obj/item/melee/energy/sword::block_chance
 	return ..()
 
 /obj/item/luna_fragment/energy_retrofit/remove_upgrade(our_sord, mob/living/user)
@@ -169,10 +169,10 @@
 	update_inhand_icon(user)
 	upgrade_appliable.set_light_on(FALSE)
 	playsound(upgrade_appliable, 'sound/weapons/saberoff.ogg', 35, TRUE)
-	force = initial(force)
-	throwforce = initial(throwforce)
-	bare_wound_bonus = initial(bare_wound_bonus)
-	demolition_mod = initial(demolition_mod)
-	armour_penetration = initial(armour_penetration)
-	block_chance = initial(block_chance)
+	upgrade_appliable.force = initial(force)
+	upgrade_appliable.throwforce = initial(throwforce)
+	upgrade_appliable.bare_wound_bonus = initial(bare_wound_bonus)
+	upgrade_appliable.demolition_mod = initial(demolition_mod)
+	upgrade_appliable.armour_penetration = initial(armour_penetration)
+	upgrade_appliable.block_chance = initial(block_chance)
 	return ..()


### PR DESCRIPTION

## About The Pull Request
Hey; did you know Luna's energy upgrade was borked to apply the esword stats to the *upgrade itself* rather than the sword?
I just found out. God; I feel stupid. Fixes it so that Luna is now mechanically all there.

See here how examining the stats actually. Works; now:
![image](https://github.com/user-attachments/assets/c389e2ab-6b6a-4696-9100-8f9edc634289)
## Changelog
:cl:
fix: Luna's energy upgrade is no longer just cosmetic.
balance: To account for some fuckery with ESword balancing, an unupgraded version of Luna has higher unarmored wound chances but even lesser armor penetration and blockchance. The energy upgrade will trade the wound bonus for the stats of an esword.
/:cl:
