### PR TITLE
Another Nova Sector Port Round

### DIFF
--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -234,11 +234,7 @@
 	return FALSE
 
 /obj/effect/mob_spawn/ghost_role/human/ash_walker/special(mob/living/carbon/human/spawned_human)
-	// EffigyEdit Change - Moved lizard name randomizer before parent call (so character names are preserved)
-	spawned_human.fully_replace_character_name(null, spawned_human.generate_random_mob_name(TRUE))
-	quirks_enabled = TRUE
 	. = ..()
-	// EffigyEdit Change End
 	to_chat(spawned_human, "<b>Drag the corpses of men and beasts to your nest. It will absorb them to create more of your kind. Invade the strange structure of the outsiders if you must. Do not cause unnecessary destruction, as littering the wastes with ugly wreckage is certain to not gain you favor. Glory to the Necropolis!</b>")
 
 	spawned_human.mind.add_antag_datum(/datum/antagonist/ashwalker, team)

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -62,7 +62,11 @@
 		spawned_human.underwear = "Nude"
 		spawned_human.undershirt = "Nude"
 		spawned_human.socks = "Nude"
-		randomize_human_normie(spawned_human)
+		//randomize_human_normie(spawned_human) // EFFIGY EDIT REMOVAL - Puts this behind if(random_appearance) - see below
+		// EFFIGY EDIT ADDITION START
+		if(random_appearance)
+			randomize_human_normie(spawned_human)
+		// EFFIGY EDIT ADDITION END
 		if(hairstyle)
 			spawned_human.set_hairstyle(hairstyle, update = FALSE)
 		if(facial_hairstyle)

--- a/local/code/controllers/subsystem/persistence.dm
+++ b/local/code/controllers/subsystem/persistence.dm
@@ -15,7 +15,7 @@ GLOBAL_LIST_INIT(modular_persistence_ignored_vars, list(
 	"tag",
 	"type",
 	"parent_type",
-	"owner",
+	"owner_brain",
 	"vars",
 	"stored_character_slot_index",
 ))
@@ -65,6 +65,9 @@ GLOBAL_LIST_INIT(modular_persistence_ignored_vars, list(
 		return
 
 	for(var/var_name in vars)
+		if(var_name in GLOB.modular_persistence_ignored_vars)
+			continue
+
 		var/var_entry = persistence_data[var_name]
 
 		if(var_entry)

--- a/local/code/modules/lewd/clothing_pref_check.dm
+++ b/local/code/modules/lewd/clothing_pref_check.dm
@@ -8,6 +8,7 @@ GLOBAL_LIST_INIT(pref_checked_clothes, list(
 	/obj/item/clothing/glasses/hypno,
 	/obj/item/clothing/neck/kink_collar,
 	/obj/item/clothing/neck/mind_collar,
+	/obj/item/electropack/shockcollar,
 	/obj/item/clothing/glasses/blindfold/kinky,
 	/obj/item/clothing/ears/kinky_headphones,
 	/obj/item/clothing/suit/straight_jacket/kinky_sleepbag,

--- a/local/code/modules/lewd/lewd_items/shibari.dm
+++ b/local/code/modules/lewd/lewd_items/shibari.dm
@@ -6,6 +6,7 @@
 /obj/item/stack/shibari_rope
 	name = "shibari ropes"
 	desc = "Coil of bondage ropes."
+	full_w_class = WEIGHT_CLASS_SMALL
 	icon = 'local/icons/lewd/obj/lewd_items/lewd_items.dmi'
 	icon_state = "shibari_rope"
 	amount = 1
@@ -39,6 +40,7 @@
 /obj/item/stack/shibari_rope/glow
 	name = "glowy shibari ropes"
 	singular_name = "glowy rope"
+	full_w_class = WEIGHT_CLASS_SMALL
 	merge_type = /obj/item/stack/shibari_rope/glow
 	icon_state = "shibari_rope_glow"
 	light_system = OVERLAY_LIGHT

--- a/local/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/local/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -17,6 +17,11 @@
 	restricted_species = list(/datum/species/lizard/ashwalker)
 	random_appearance = FALSE
 
+/obj/effect/mob_spawn/ghost_role/human/ash_walker/special(mob/living/carbon/human/spawned_human)
+	spawned_human.fully_replace_character_name(null, spawned_human.generate_random_mob_name(TRUE))
+	quirks_enabled = TRUE // ghost role quirks
+	. = ..()
+
 /obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate
 	loadout_enabled = TRUE
 	quirks_enabled = TRUE

--- a/local/code/modules/mob_spawn/mob_spawn.dm
+++ b/local/code/modules/mob_spawn/mob_spawn.dm
@@ -1,6 +1,8 @@
-/obj/effect/mob_spawn/ghost_role
-	/// Do we use a random appearance for this ghost role?
+/obj/effect/mob_spawn
+	/// Do we use a random appearance for this role?
 	var/random_appearance = TRUE
+
+/obj/effect/mob_spawn/ghost_role
 	/// Can we use our loadout for this role?
 	var/loadout_enabled = FALSE
 	/// Can we use our quirks for this role?


### PR DESCRIPTION
:cl: 00-Steven, FearfulFurnishing, dis-integrates-the-integration-tests for Nova Sector
fix: Fixed NIF persistence.
fix: fixes ghost roles sometimes being given random mutant body parts if no selection for the part was made
fix: Shock Collar is now properly recognized as a lewd item, and thus can be removed using the Remove verb.
qol: Shibari Rope stacks now fit in boxes.
/:cl:
