### PR TITLE
[PORT] Updated Pixelshifting From Skyrat

### DIFF
--- a/code/__DEFINES/_effigy/keybindings.dm
+++ b/code/__DEFINES/_effigy/keybindings.dm
@@ -1,4 +1,8 @@
 #define COMSIG_KB_MOB_PIXEL_SHIFT_DOWN "keybinding_mob_pixel_shift_down"
 #define COMSIG_KB_MOB_PIXEL_SHIFT_UP "keybinding_mob_pixel_shift_up"
+#define COMSIG_KB_MOB_ITEM_PIXEL_SHIFT_DOWN "keybinding_mob_item_pixelshift_down"
+#define COMSIG_KB_MOB_ITEM_PIXEL_SHIFT_UP "keybinding_mob_item_pixelshift_up"
+#define COMSIG_KB_MOB_PIXEL_TILT_DOWN "keybinding_mob_pixeltilt_down"
+#define COMSIG_KB_MOB_PIXEL_TILT_UP "keybinding_mob_pixeltilt_up"
 #define COMSIG_KB_CLIENT_LOOC_DOWN "keybinding_client_looc_down"
 #define COMSIG_KB_CLIENT_WHISPER_DOWN "keybinding_client_whisper_down"

--- a/local/code/datums/components/pixel_shift_component.dm
+++ b/local/code/datums/components/pixel_shift_component.dm
@@ -1,15 +1,23 @@
+#define SHIFTING_ITEMS 1
+#define SHIFTING_PARENT 2
+#define TILTING_PARENT 3
+
 /datum/component/pixel_shift
 	dupe_mode = COMPONENT_DUPE_UNIQUE
-	/// Whether the mob is pixel shifted or not
-	var/is_shifted = FALSE
-	/// If we are in the shifting setting.
-	var/shifting = TRUE
-	/// Takes the four cardinal direction defines. Any atoms moving into this atom's tile will be allowed to from the added directions.
-	var/passthroughable = NONE
-	/// The maximum amount of pixels allowed to move in the turf.
+	//whether or not parent is shifting
+	var/shifting = FALSE
+	//how tilted the parent is
+	var/how_tilted
+	//the maximum amount of tilt parent can achieve
+	var/maximum_tilt = 45
+	//the maximum amount we/an item can move
 	var/maximum_pixel_shift = 16
-	/// The amount of pixel shift required to make the parent passthroughable.
-	var/passable_shift_threshold = 8
+	//If we are shifted
+	var/is_shifted = FALSE
+	//Allows atoms entering Parent's turf to pass through freely from given directions
+	var/passthroughable = NONE
+	//Amount of shifting necessary to make the parent passthroughable
+	var/passthrough_threshold = 8
 
 /datum/component/pixel_shift/Initialize(...)
 	. = ..()
@@ -17,27 +25,60 @@
 		return COMPONENT_INCOMPATIBLE
 
 /datum/component/pixel_shift/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_KB_MOB_ITEM_PIXEL_SHIFT_DOWN, PROC_REF(item_pixel_shift_down))
+	RegisterSignal(parent, COMSIG_KB_MOB_ITEM_PIXEL_SHIFT_UP, PROC_REF(item_pixel_shift_up))
 	RegisterSignal(parent, COMSIG_KB_MOB_PIXEL_SHIFT_DOWN, PROC_REF(pixel_shift_down))
 	RegisterSignal(parent, COMSIG_KB_MOB_PIXEL_SHIFT_UP, PROC_REF(pixel_shift_up))
+	RegisterSignal(parent, COMSIG_KB_MOB_PIXEL_TILT_DOWN, PROC_REF(pixel_tilt_down))
+	RegisterSignal(parent, COMSIG_KB_MOB_PIXEL_TILT_UP, PROC_REF(pixel_tilt_up))
 	RegisterSignals(parent, list(COMSIG_LIVING_RESET_PULL_OFFSETS, COMSIG_LIVING_SET_PULL_OFFSET, COMSIG_MOVABLE_MOVED), PROC_REF(unpixel_shift))
 	RegisterSignal(parent, COMSIG_MOB_CLIENT_PRE_LIVING_MOVE, PROC_REF(pre_move_check))
 	RegisterSignal(parent, COMSIG_LIVING_CAN_ALLOW_THROUGH, PROC_REF(check_passable))
-
 /datum/component/pixel_shift/UnregisterFromParent()
-	UnregisterSignal(parent, COMSIG_KB_MOB_PIXEL_SHIFT_DOWN)
-	UnregisterSignal(parent, COMSIG_KB_MOB_PIXEL_SHIFT_UP)
-	UnregisterSignal(parent, COMSIG_LIVING_RESET_PULL_OFFSETS)
-	UnregisterSignal(parent, COMSIG_LIVING_SET_PULL_OFFSET)
-	UnregisterSignal(parent, COMSIG_MOVABLE_MOVED)
-	UnregisterSignal(parent, COMSIG_MOB_CLIENT_PRE_LIVING_MOVE)
-	UnregisterSignal(parent, COMSIG_LIVING_CAN_ALLOW_THROUGH)
+	UnregisterSignal(parent, list(
+		COMSIG_KB_MOB_ITEM_PIXEL_SHIFT_DOWN,
+		COMSIG_KB_MOB_ITEM_PIXEL_SHIFT_UP,
+		COMSIG_KB_MOB_PIXEL_TILT_DOWN,
+		COMSIG_KB_MOB_PIXEL_TILT_UP,
+		COMSIG_KB_MOB_PIXEL_SHIFT_DOWN,
+		COMSIG_KB_MOB_PIXEL_SHIFT_UP,
+		COMSIG_MOB_CLIENT_PRE_LIVING_MOVE,
+		COMSIG_LIVING_RESET_PULL_OFFSETS,
+		COMSIG_LIVING_SET_PULL_OFFSET,
+		COMSIG_MOVABLE_MOVED,
+		COMSIG_LIVING_CAN_ALLOW_THROUGH,
+	))
 
-/// Overrides Move to Pixel Shift.
+//locks our movement when holding our keybinds
 /datum/component/pixel_shift/proc/pre_move_check(mob/source, new_loc, direct)
 	SIGNAL_HANDLER
 	if(shifting)
 		pixel_shift(source, direct)
 		return COMSIG_MOB_CLIENT_BLOCK_PRE_LIVING_MOVE
+
+//procs for tilting parent
+
+/datum/component/pixel_shift/proc/pixel_tilt_down()
+	SIGNAL_HANDLER
+	shifting = TILTING_PARENT
+	return COMSIG_KB_ACTIVATED
+
+/datum/component/pixel_shift/proc/pixel_tilt_up()
+	SIGNAL_HANDLER
+	shifting = FALSE
+
+//Procs for shifting items
+
+/datum/component/pixel_shift/proc/item_pixel_shift_down()
+	SIGNAL_HANDLER
+	shifting = SHIFTING_ITEMS
+	return COMSIG_KB_ACTIVATED
+
+/datum/component/pixel_shift/proc/item_pixel_shift_up()
+	SIGNAL_HANDLER
+	shifting = FALSE
+
+//Procs for shifting mobs
 
 /// Checks if the parent is considered passthroughable from a direction. Projectiles will ignore the check and hit.
 /datum/component/pixel_shift/proc/check_passable(mob/source, atom/movable/mover, border_dir)
@@ -48,7 +89,7 @@
 /// Activates Pixel Shift on Keybind down. Only Pixel Shift movement will be allowed.
 /datum/component/pixel_shift/proc/pixel_shift_down()
 	SIGNAL_HANDLER
-	shifting = TRUE
+	shifting = SHIFTING_PARENT
 	return COMSIG_KB_ACTIVATED
 
 /// Disables Pixel Shift on Keybind up. Allows to Move.
@@ -64,37 +105,74 @@
 		var/mob/living/owner = parent
 		owner.pixel_x = owner.body_position_pixel_x_offset + owner.base_pixel_x
 		owner.pixel_y = owner.body_position_pixel_y_offset + owner.base_pixel_y
+		owner.transform = turn(owner.transform, -how_tilted)
 	qdel(src)
 
 /// In-turf pixel movement which can allow things to pass through if the threshold is met.
 /datum/component/pixel_shift/proc/pixel_shift(mob/source, direct)
 	passthroughable = NONE
 	var/mob/living/owner = parent
-	switch(direct)
-		if(NORTH)
-			if(owner.pixel_y <= maximum_pixel_shift + owner.base_pixel_y)
-				owner.pixel_y++
-				is_shifted = TRUE
-		if(EAST)
-			if(owner.pixel_x <= maximum_pixel_shift + owner.base_pixel_x)
-				owner.pixel_x++
-				is_shifted = TRUE
-		if(SOUTH)
-			if(owner.pixel_y >= -maximum_pixel_shift + owner.base_pixel_y)
-				owner.pixel_y--
-				is_shifted = TRUE
-		if(WEST)
-			if(owner.pixel_x >= -maximum_pixel_shift + owner.base_pixel_x)
-				owner.pixel_x--
-				is_shifted = TRUE
+	switch(shifting)
+		if(SHIFTING_ITEMS)
+			var/atom/pulled_atom = source.pulling
+			if(!isitem(pulled_atom))
+				return
+			var/obj/item/pulled_item = pulled_atom
+			switch(direct)
+				if(NORTH)
+					if(pulled_item.pixel_y <= maximum_pixel_shift + pulled_item.base_pixel_y)
+						pulled_item.pixel_y++
+				if(EAST)
+					if(pulled_item.pixel_x <= maximum_pixel_shift + pulled_item.base_pixel_x)
+						pulled_item.pixel_x++
+				if(SOUTH)
+					if(pulled_item.pixel_y >= -maximum_pixel_shift + pulled_item.base_pixel_y)
+						pulled_item.pixel_y--
+				if(WEST)
+					if(pulled_item.pixel_x >= -maximum_pixel_shift + pulled_item.base_pixel_x)
+						pulled_item.pixel_x--
+		if(SHIFTING_PARENT)
+			switch(direct)
+				if(NORTH)
+					if(owner.pixel_y <= maximum_pixel_shift + owner.base_pixel_y)
+						owner.pixel_y++
+						is_shifted = TRUE
+				if(EAST)
+					if(owner.pixel_x <= maximum_pixel_shift + owner.base_pixel_x)
+						owner.pixel_x++
+						is_shifted = TRUE
+				if(SOUTH)
+					if(owner.pixel_y >= -maximum_pixel_shift + owner.base_pixel_y)
+						owner.pixel_y--
+						is_shifted = TRUE
+				if(WEST)
+					if(owner.pixel_x >= -maximum_pixel_shift + owner.base_pixel_x)
+						owner.pixel_x--
+						is_shifted = TRUE
+		if(TILTING_PARENT)
+			switch(direct)
+				if(EAST)
+					if(how_tilted <= maximum_tilt)
+						owner.transform = turn(owner.transform, 1)
+						how_tilted++
+						is_shifted = TRUE
+				if(WEST)
+					if(how_tilted >= -maximum_tilt)
+						owner.transform = turn(owner.transform, -1)
+						how_tilted--
+						is_shifted = TRUE
 
 	// Yes, I know this sets it to true for everything if more than one is matched.
 	// Movement doesn't check diagonals, and instead just checks EAST or WEST, depending on where you are for those.
-	if(owner.pixel_y > passable_shift_threshold)
+	if(owner.pixel_y > passthrough_threshold)
 		passthroughable |= EAST | SOUTH | WEST
-	else if(owner.pixel_y < -passable_shift_threshold)
+	else if(owner.pixel_y < -passthrough_threshold)
 		passthroughable |= NORTH | EAST | WEST
-	if(owner.pixel_x > passable_shift_threshold)
+	if(owner.pixel_x > passthrough_threshold)
 		passthroughable |= NORTH | SOUTH | WEST
-	else if(owner.pixel_x < -passable_shift_threshold)
+	else if(owner.pixel_x < -passthrough_threshold)
 		passthroughable |= NORTH | EAST | SOUTH
+
+#undef SHIFTING_ITEMS
+#undef SHIFTING_PARENT
+#undef TILTING_PARENT

--- a/local/code/datums/keybinding/mob.dm
+++ b/local/code/datums/keybinding/mob.dm
@@ -1,3 +1,22 @@
+/datum/keybinding/mob/item_pixel_shift
+	hotkey_keys = list("V")
+	name = "item_pixel_shift"
+	full_name = "Item Pixel Shift"
+	description = "Shift a pulled item's offset."
+	category = CATEGORY_MISC
+	keybind_signal = COMSIG_KB_MOB_ITEM_PIXEL_SHIFT_DOWN
+
+/datum/keybinding/mob/item_pixel_shift/down(client/user)
+	. = ..()
+	if(.)
+		return
+	user.mob.AddComponent(/datum/component/pixel_shift)
+	SEND_SIGNAL(user.mob, COMSIG_KB_MOB_ITEM_PIXEL_SHIFT_DOWN)
+
+/datum/keybinding/mob/item_pixel_shift/up(client/user)
+	. = ..()
+	SEND_SIGNAL(user.mob, COMSIG_KB_MOB_ITEM_PIXEL_SHIFT_UP)
+
 /datum/keybinding/mob/pixel_shift
 	hotkey_keys = list("B")
 	name = "pixel_shift"
@@ -10,8 +29,28 @@
 	. = ..()
 	if(.)
 		return
-	user.mob.add_pixel_shift_component()
+	user.mob.AddComponent(/datum/component/pixel_shift)
+	SEND_SIGNAL(user.mob, COMSIG_KB_MOB_PIXEL_SHIFT_DOWN)
 
 /datum/keybinding/mob/pixel_shift/up(client/user)
 	. = ..()
 	SEND_SIGNAL(user.mob, COMSIG_KB_MOB_PIXEL_SHIFT_UP)
+
+/datum/keybinding/mob/pixel_tilting
+	hotkey_keys = list("N")
+	name = "Pixel Tilting"
+	full_name = "Pixel Tilt"
+	description = "Shift your mob's rotational value."
+	category = CATEGORY_MOVEMENT
+	keybind_signal = COMSIG_KB_MOB_PIXEL_TILT_DOWN
+
+/datum/keybinding/mob/pixel_tilting/down(client/user)
+	. = ..()
+	if(.)
+		return
+	user.mob.AddComponent(/datum/component/pixel_shift)
+	SEND_SIGNAL(user.mob, COMSIG_KB_MOB_PIXEL_TILT_DOWN)
+
+/datum/keybinding/mob/pixel_tilting/up(client/user)
+	. = ..()
+	SEND_SIGNAL(user.mob, COMSIG_KB_MOB_PIXEL_TILT_UP)

--- a/local/code/modules/mob/living/living.dm
+++ b/local/code/modules/mob/living/living.dm
@@ -16,7 +16,3 @@
 /mob/living/reset_pull_offsets(mob/living/pull_target, override)
 	. = ..()
 	SEND_SIGNAL(pull_target, COMSIG_LIVING_RESET_PULL_OFFSETS)
-
-
-/mob/living/add_pixel_shift_component()
-	AddComponent(/datum/component/pixel_shift)


### PR DESCRIPTION
Adds the ability to pixelshift pulled items & tilt yourself; and optimizes pixelshifting code significantly. ALL codework within is by Odairu. This is a direct port with minimal, strictly spelling and phrasing related changes.

I'm counting this as a feature parity measure considering pixelshifting was grandfathered from skyrat.

![image](https://github.com/user-attachments/assets/e0284819-2b22-4f27-aeef-6e38dda307ac)



:cl: Odairu for Skyrat 13
add: adds pixel shifting items, and pixel tilting mobs
code: optimizes pixelshifting
/:cl:
