### PR TITLE
Fixes Character name cutoff on Splash Menu

### DIFF
--- a/config/splash_html.txt
+++ b/config/splash_html.txt
@@ -95,7 +95,7 @@
 				.container_nav {
 					position: absolute;
 					box-sizing: border-box;
-					width: 75vmin;
+					width: auto;
 					min-height: 10vmin;
 					top: calc(50% + 22.5vmin);
 					left:50%;


### PR DESCRIPTION
## About The Pull Request
This pull is a single-line change in a text file (/config/splash_html.txt) which prevents #954 from occurring.

The existing maximum string length of a character name AND the `Character Setup (` ... `)` is shorter than the default width of the screen, so that you cannot have a SAVED character preference which exceeds the bounds of the screen and obscures the splash menu options.

Tested on a local server.

Same name used in #954, to show improvement:
![fix1](https://github.com/user-attachments/assets/d298bc27-1a6a-44e3-95fc-c28cf59a801e)
Maximum string length saveable to a character preference:
![fix2](https://github.com/user-attachments/assets/f333a1f6-7563-47c0-a6ad-70ff11d44d86)

## Why It's Good For The Game
Longer names will no longer be cut off 👍 

## Changelog

:cl: alos
qol: Splash menu button container width is now Auto
/:cl: