### PR TITLE
HTML encoded-characters disallowed for chameleon ID Bug Fix

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1657,7 +1657,7 @@
 		return
 
 	///forge the ID if not forged.
-	var/input_name = tgui_input_text(user, "What name would you like to put on this card? Leave blank to randomise.", "Agent card name", registered_name ? registered_name : (ishuman(user) ? user.real_name : user.name), MAX_NAME_LEN)
+	var/input_name = tgui_input_text(user, "What name would you like to put on this card? Leave blank to randomise.", "Agent card name", registered_name ? registered_name : (ishuman(user) ? user.real_name : user.name), MAX_NAME_LEN, encode = FALSE)
 	if(!after_input_check(user))
 		return TRUE
 	if(input_name)


### PR DESCRIPTION
## About The Pull Request

**DO NOT MERGE - STILL FIGURING OUT WHY IT GOES `NA'ME (AS NA'ME)` RATHER THAN JUST -- `NA'ME`**

This PR allows characters to include HTML-encoded characters in their agent card's name.

## Why It's Good For The Game
This fixes a bug where a chameleon ID card using a mob's real_name, if it includes HTML-encoded characters, displays it with those raw HTML codes, e.g. `&#39;` for an apostrophe.

## Changelog

:cl: alos
fix: allowed for HTML encoding in agent card names
/:cl: