### PR TITLE
Fixes Neck Loadout Options & More Quarks

### DIFF
--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -1387,6 +1387,7 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
 /area/station/security/checkpoint/supply)
 "aBD" = (
@@ -10837,6 +10838,7 @@
 	name = "Checkpoint Shutter";
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/engineering)
 "dUx" = (
@@ -17358,6 +17360,7 @@
 /obj/effect/landmark/start/depsec/science,
 /obj/effect/turf_decal/trimline/dark_red/warning,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/checkpoint/science)
 "gkQ" = (
@@ -20579,6 +20582,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/security/checkpoint/supply)
 "hwu" = (
@@ -25149,6 +25153,7 @@
 	id = "scisec_shutters";
 	name = "Checkpoint Shutter"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/science)
 "jgU" = (
@@ -29021,12 +29026,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/science/robotics)
-"kzU" = (
-/obj/effect/turf_decal/siding/wideplating_new/corner{
-	dir = 1
-	},
-/turf/open/floor/asphalt,
-/area/taeloth/nearstation/cargo_crossway/pavement)
 "kAc" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/smartfridge/petri/preloaded,
@@ -37716,6 +37715,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/checkpoint/science)
 "nMk" = (
@@ -53301,6 +53301,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
+"tpO" = (
+/obj/effect/turf_decal/siding/wideplating_new/corner{
+	dir = 1
+	},
+/turf/open/floor/asphalt,
+/area/taeloth/nearstation/cargo_crossway/pavement)
 "tpQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -58169,6 +58175,7 @@
 	id = "carsec_shutters";
 	name = "Checkpoint Shutter"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/supply)
 "vfq" = (
@@ -60783,12 +60790,6 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/misc/grass/jungle,
 /area/taeloth)
-"vZM" = (
-/obj/effect/turf_decal/siding/wideplating_new{
-	dir = 1
-	},
-/turf/open/floor/asphalt,
-/area/taeloth/nearstation/cargo_crossway/pavement)
 "vZX" = (
 /obj/machinery/suit_storage_unit/hos,
 /obj/effect/turf_decal/tile/dark_red/full,
@@ -64886,6 +64887,12 @@
 /obj/effect/landmark/navigate_destination/vault,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/command/nuke_storage)
+"xyU" = (
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
+	},
+/turf/open/floor/asphalt,
+/area/taeloth/nearstation/cargo_crossway/pavement)
 "xyY" = (
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 6
@@ -102294,7 +102301,7 @@ wdx
 udu
 xzy
 bPv
-vZM
+xyU
 cBl
 cBl
 fyD
@@ -102551,7 +102558,7 @@ xPi
 inj
 tac
 vxC
-kzU
+tpO
 cBl
 cBl
 fyD

--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -117,11 +117,14 @@
 /obj/effect/turf_decal/trimline/dark_red/end{
 	dir = 4
 	},
+/obj/structure/closet/firecloset,
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
 	},
-/obj/structure/closet/firecloset,
-/turf/open/misc/asteroid/moon,
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large,
 /area/taeloth/nearstation/cargo_crossway/pavement)
 "adr" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1453,7 +1456,7 @@
 /area/station/command/heads_quarters/hop)
 "aDC" = (
 /obj/structure/sign/poster/official/random/directional/north,
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "aDP" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -4688,11 +4691,9 @@
 /obj/effect/turf_decal/trimline/dark_blue/end{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wideplating_new{
-	dir = 8
-	},
 /obj/structure/closet/emcloset,
-/turf/open/misc/asteroid/moon,
+/obj/effect/turf_decal/siding/wideplating_new/end,
+/turf/open/floor/iron/smooth_large,
 /area/taeloth/nearstation/cargo_crossway/pavement)
 "bMB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4850,7 +4851,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/iron/dark/textured_large,
 /area/taeloth/nearstation/cargo_crossway/pavement)
 "bPG" = (
 /obj/structure/reflector/double/anchored{
@@ -7058,7 +7059,7 @@
 	},
 /area/station/holodeck/rec_center)
 "cBl" = (
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/cargo_crossway/pavement)
 "cBz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -13114,7 +13115,7 @@
 /obj/machinery/solarlight/camera_installed{
 	c_tag = "Exterior - Crew Facilities, South"
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "eKx" = (
 /obj/structure/bed/double,
@@ -14537,7 +14538,7 @@
 /obj/effect/turf_decal/trimline/brown/line{
 	dir = 4
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/cargo_crossway/pavement)
 "fld" = (
 /obj/effect/turf_decal/siding/wideplating_new/light{
@@ -15372,7 +15373,7 @@
 /area/taeloth/nearstation/medical_roof)
 "fyD" = (
 /obj/effect/turf_decal/siding/wideplating_new,
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/cargo_crossway/pavement)
 "fyE" = (
 /obj/machinery/lift_indicator/directional/north{
@@ -15982,7 +15983,7 @@
 /obj/structure/fence{
 	dir = 4
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "fLu" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -21789,7 +21790,7 @@
 /area/station/science)
 "hRz" = (
 /obj/structure/chair/sofa/bench/right,
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "hRF" = (
 /obj/machinery/rnd/production/techfab/department/medical,
@@ -25782,7 +25783,7 @@
 /obj/effect/turf_decal/trimline/brown/line{
 	dir = 1
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/cargo_crossway/pavement)
 "jti" = (
 /obj/structure/table/reinforced,
@@ -25965,7 +25966,7 @@
 	dir = 8
 	},
 /obj/effect/spawner/random/trash/bin,
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "jvR" = (
 /obj/machinery/firealarm/directional/south,
@@ -29020,6 +29021,12 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/science/robotics)
+"kzU" = (
+/obj/effect/turf_decal/siding/wideplating_new/corner{
+	dir = 1
+	},
+/turf/open/floor/asphalt,
+/area/taeloth/nearstation/cargo_crossway/pavement)
 "kAc" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/smartfridge/petri/preloaded,
@@ -29984,7 +29991,7 @@
 /obj/structure/fence/end{
 	dir = 8
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "kSL" = (
 /obj/structure/cable,
@@ -30774,7 +30781,7 @@
 /area/taeloth/nearstation/restroom_roof)
 "ljb" = (
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "ljd" = (
 /obj/structure/chair/wood{
@@ -32164,7 +32171,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "lLq" = (
 /obj/effect/turf_decal/siding/wideplating_new/light{
@@ -33277,7 +33284,7 @@
 "mgP" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/dark_red/end,
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "mgS" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -34294,7 +34301,7 @@
 /obj/structure/fence{
 	dir = 4
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "myJ" = (
 /obj/effect/turf_decal/tile/blue/diagonal_edge,
@@ -35584,7 +35591,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "mXN" = (
 /obj/machinery/airlock_sensor/incinerator_ordmix{
@@ -38350,7 +38357,7 @@
 /obj/effect/turf_decal/trimline/brown/corner{
 	dir = 4
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/cargo_crossway/pavement)
 "oas" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -38571,7 +38578,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "oef" = (
 /obj/structure/disposalpipe/segment{
@@ -45893,7 +45900,7 @@
 /obj/machinery/solarlight/camera_installed{
 	c_tag = "Exterior -  Cargo, West"
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/cargo_crossway/pavement)
 "qLC" = (
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
@@ -49033,7 +49040,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/cargo_crossway/pavement)
 "rRj" = (
 /obj/machinery/computer/cargo/request{
@@ -52678,7 +52685,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "tdA" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
@@ -54492,7 +54499,7 @@
 /area/taeloth/nearstation/service_roof)
 "tPV" = (
 /obj/effect/landmark/start/hangover,
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/cargo_crossway/pavement)
 "tPW" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
@@ -55876,7 +55883,7 @@
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 8
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "uoe" = (
 /obj/effect/turf_decal/siding/wideplating_new{
@@ -58183,7 +58190,7 @@
 	dir = 1
 	},
 /obj/item/kirbyplants/random,
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "vfU" = (
 /obj/structure/sign/painting/library_private{
@@ -58785,7 +58792,7 @@
 /area/station/science/robotics/augments)
 "vqg" = (
 /obj/structure/chair/sofa/bench/left,
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "vqr" = (
 /obj/machinery/door/airlock/security/glass,
@@ -59142,7 +59149,7 @@
 /obj/effect/turf_decal/trimline/brown/corner{
 	dir = 4
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/cargo_crossway/pavement)
 "vwU" = (
 /obj/machinery/light/small/directional/east,
@@ -59179,7 +59186,10 @@
 /obj/effect/turf_decal/trimline/brown/corner{
 	dir = 4
 	},
-/turf/open/misc/asteroid/moon,
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 8
+	},
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/cargo_crossway/pavement)
 "vxD" = (
 /obj/effect/turf_decal/siding/wideplating_new/corner{
@@ -60773,6 +60783,12 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/misc/grass/jungle,
 /area/taeloth)
+"vZM" = (
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
+	},
+/turf/open/floor/asphalt,
+/area/taeloth/nearstation/cargo_crossway/pavement)
 "vZX" = (
 /obj/machinery/suit_storage_unit/hos,
 /obj/effect/turf_decal/tile/dark_red/full,
@@ -61030,7 +61046,7 @@
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "wfp" = (
 /obj/effect/turf_decal/siding/wood{
@@ -62543,7 +62559,7 @@
 /obj/structure/railing/corner/end/flip{
 	dir = 1
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/cargo_crossway/pavement)
 "wIl" = (
 /obj/structure/sign/departments/holy/directional/east,
@@ -63885,7 +63901,7 @@
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 1
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "xgz" = (
 /obj/effect/turf_decal/stripes/line{
@@ -65764,7 +65780,7 @@
 /turf/open/misc/dirt/jungle,
 /area/taeloth/nearstation/service_roof)
 "xOC" = (
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
 "xOH" = (
 /obj/structure/railing{
@@ -66418,7 +66434,7 @@
 /obj/effect/turf_decal/trimline/brown/mid_joiner{
 	dir = 1
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/cargo_crossway/pavement)
 "yak" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/end{
@@ -66696,7 +66712,7 @@
 /obj/effect/turf_decal/trimline/brown/corner{
 	dir = 1
 	},
-/turf/open/misc/asteroid/moon,
+/turf/open/floor/asphalt,
 /area/taeloth/nearstation/cargo_crossway/pavement)
 "yfL" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -102278,7 +102294,7 @@ wdx
 udu
 xzy
 bPv
-cBl
+vZM
 cBl
 cBl
 fyD
@@ -102535,7 +102551,7 @@ xPi
 inj
 tac
 vxC
-cBl
+kzU
 cBl
 cBl
 fyD

--- a/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
+++ b/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
@@ -21280,6 +21280,10 @@
 /area/station/maintenance/department/engine/atmos)
 "eNs" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "geneticsprivacy";
+	name = "Genetics Shutters"
+	},
 /turf/open/floor/plating,
 /area/station/science/genetics)
 "eNF" = (
@@ -26614,6 +26618,11 @@
 	pixel_y = 4
 	},
 /obj/item/toy/figure/geneticist,
+/obj/machinery/button/door/directional/west{
+	id = "geneticsprivacy";
+	req_access = list("genetics");
+	name = "Genetics Shutters"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "fZw" = (
@@ -28464,6 +28473,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor1/aft)
+"gtV" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/maintenance/floor2/port/aft)
 "gtY" = (
 /obj/structure/cable/layer3,
 /obj/structure/cable,
@@ -32598,6 +32611,10 @@
 	},
 /turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/central)
+"hqr" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/maintenance/floor2/port)
 "hqt" = (
 /obj/structure/table/wood,
 /obj/item/phone{
@@ -36320,7 +36337,7 @@
 	},
 /area/station/cargo/warehouse)
 "imE" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "imI" = (
@@ -48825,6 +48842,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/station/maintenance/floor2/port/aft)
+"leL" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "leN" = (
 /turf/open/floor/glass/reinforced,
 /area/station/maintenance/department/cargo)
@@ -51927,6 +51948,10 @@
 "lSO" = (
 /turf/closed/wall,
 /area/station/cargo/lobby)
+"lSQ" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/maintenance/floor2/starboard/aft)
 "lST" = (
 /obj/effect/baseturf_helper/reinforced_plating/ceiling,
 /turf/closed/wall/r_wall,
@@ -68868,7 +68893,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/floor1)
 "pSd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window,
 /obj/effect/mapping_helpers/damaged_window,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
@@ -81461,10 +81486,6 @@
 "sPb" = (
 /obj/machinery/door/firedoor/water_sensor,
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/north{
-	name = "Genetics Desk";
-	req_access = list("genetics")
-	},
 /obj/structure/desk_bell{
 	pixel_x = -6;
 	pixel_y = 7
@@ -81474,6 +81495,14 @@
 	},
 /obj/item/pen{
 	pixel_x = 3
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "geneticsprivacy";
+	name = "Genetics Shutters"
+	},
+/obj/machinery/door/window/left/directional/north{
+	name = "Genetics Desk";
+	req_access = list("genetics")
 	},
 /turf/open/floor/plating,
 /area/station/science/genetics)
@@ -181687,8 +181716,8 @@ ejW
 gSm
 mEO
 ejW
-cJs
-cJs
+lSQ
+lSQ
 ejW
 gkW
 glA
@@ -182670,7 +182699,7 @@ kOZ
 kOZ
 kOZ
 kOZ
-wYw
+gtV
 nDC
 vKW
 lpQ
@@ -182927,7 +182956,7 @@ wix
 bYU
 kOZ
 kOZ
-wYw
+gtV
 gYw
 qKV
 flz
@@ -194234,7 +194263,7 @@ cBP
 vOG
 emv
 tho
-chu
+leL
 wMU
 jrR
 eeA
@@ -194491,7 +194520,7 @@ dPt
 teE
 dHA
 lbR
-chu
+leL
 hCG
 jrR
 pUt
@@ -203745,8 +203774,8 @@ cnI
 vAa
 gDq
 lUy
-eHR
-eHR
+hqr
+hqr
 lUy
 anL
 lUy

--- a/_maps/effigy/templates/condos/alleyway.dmm
+++ b/_maps/effigy/templates/condos/alleyway.dmm
@@ -3,11 +3,11 @@
 /obj/effect/turf_decal/siding/thinplating_new/terracotta{
 	dir = 1
 	},
-/turf/open/indestructible/boss/air,
+/turf/open/floor/asphalt,
 /area/misc/condo)
 "b" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/boss/air,
+/turf/open/floor/asphalt,
 /area/misc/condo)
 "e" = (
 /obj/structure/sign/poster/official/report_crimes/directional/north,
@@ -32,7 +32,7 @@
 /area/misc/condo)
 "l" = (
 /obj/effect/light_emitter/fake_outdoors,
-/turf/open/indestructible/boss/air,
+/turf/open/floor/asphalt,
 /area/misc/condo)
 "o" = (
 /obj/structure/sign/poster/official/walk/directional/north,
@@ -49,7 +49,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/boss/air,
+/turf/open/floor/asphalt,
 /area/misc/condo)
 "r" = (
 /turf/open/misc/asteroid/moon,
@@ -67,7 +67,7 @@
 /turf/open/floor/iron/textured_large,
 /area/misc/condo)
 "B" = (
-/turf/open/indestructible/boss/air,
+/turf/open/floor/asphalt,
 /area/misc/condo)
 "E" = (
 /obj/effect/turf_decal/siding/dark,
@@ -83,7 +83,7 @@
 /area/misc/condo)
 "J" = (
 /obj/effect/turf_decal/trimline/white/line,
-/turf/open/indestructible/boss/air,
+/turf/open/floor/asphalt,
 /area/misc/condo)
 "K" = (
 /turf/closed/indestructible/hoteldoor/fakedoor,
@@ -111,7 +111,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line,
-/turf/open/indestructible/boss/air,
+/turf/open/floor/asphalt,
 /area/misc/condo)
 
 (1,1,1) = {"

--- a/_maps/effigy/templates/condos/beach_condo.dmm
+++ b/_maps/effigy/templates/condos/beach_condo.dmm
@@ -88,8 +88,8 @@
 	},
 /area/misc/condo)
 "qe" = (
-/turf/template_noop,
-/area/template_noop)
+/turf/cordon,
+/area/misc/condo)
 "qm" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 9

--- a/_maps/effigy/templates/condos/dsthree_condo.dmm
+++ b/_maps/effigy/templates/condos/dsthree_condo.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "an" = (
-/turf/template_noop,
-/area/template_noop)
+/turf/cordon,
+/area/misc/condo)
 "bZ" = (
 /obj/machinery/light/directional/west,
 /obj/structure/table,

--- a/_maps/effigy/templates/condos/foxhole_chapel.dmm
+++ b/_maps/effigy/templates/condos/foxhole_chapel.dmm
@@ -707,8 +707,8 @@
 /turf/open/floor/wood/tile,
 /area/misc/condo)
 "ZA" = (
-/turf/template_noop,
-/area/template_noop)
+/turf/cordon,
+/area/misc/condo)
 
 (1,1,1) = {"
 ZA

--- a/_maps/effigy/templates/condos/gm_condo.dmm
+++ b/_maps/effigy/templates/condos/gm_condo.dmm
@@ -32,8 +32,8 @@
 /turf/open/floor/grass,
 /area/misc/condo)
 "fA" = (
-/turf/template_noop,
-/area/template_noop)
+/turf/cordon,
+/area/misc/condo)
 "fB" = (
 /obj/effect/planetary_turf_atmos_helper,
 /turf/closed/indestructible/wood,

--- a/_maps/effigy/templates/condos/holestation_bridge.dmm
+++ b/_maps/effigy/templates/condos/holestation_bridge.dmm
@@ -389,9 +389,6 @@
 /obj/structure/closet/secure_closet/personal/fake_captain,
 /turf/open/floor/iron/dark,
 /area/misc/condo)
-"Ss" = (
-/turf/template_noop,
-/area/template_noop)
 "Th" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -595,10 +592,10 @@ ei
 ET
 tN
 DU
-Ss
-Ss
-Ss
-Ss
+DU
+DU
+DU
+DU
 "}
 (10,1,1) = {"
 hf
@@ -612,10 +609,10 @@ jB
 tu
 tN
 DU
-Ss
-Ss
-Ss
-Ss
+DU
+DU
+DU
+DU
 "}
 (11,1,1) = {"
 hf
@@ -629,10 +626,10 @@ Th
 yt
 tN
 DU
-Ss
-Ss
-Ss
-Ss
+DU
+DU
+DU
+DU
 "}
 (12,1,1) = {"
 hf
@@ -646,10 +643,10 @@ KV
 yt
 tN
 DU
-Ss
-Ss
-Ss
-Ss
+DU
+DU
+DU
+DU
 "}
 (13,1,1) = {"
 hf
@@ -663,10 +660,10 @@ OI
 Lm
 tN
 DU
-Ss
-Ss
-Ss
-Ss
+DU
+DU
+DU
+DU
 "}
 (14,1,1) = {"
 hf
@@ -680,10 +677,10 @@ KV
 xn
 tN
 DU
-Ss
-Ss
-Ss
-Ss
+DU
+DU
+DU
+DU
 "}
 (15,1,1) = {"
 hf
@@ -697,10 +694,10 @@ DS
 Ae
 tN
 DU
-Ss
-Ss
-Ss
-Ss
+DU
+DU
+DU
+DU
 "}
 (16,1,1) = {"
 hf
@@ -714,8 +711,8 @@ tN
 tN
 tN
 DU
-Ss
-Ss
-Ss
-Ss
+DU
+DU
+DU
+DU
 "}

--- a/_maps/effigy/templates/condos/lodge_pool.dmm
+++ b/_maps/effigy/templates/condos/lodge_pool.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/template_noop,
-/area/template_noop)
+/turf/cordon,
+/area/misc/condo)
 "b" = (
 /turf/open/floor/iron/showroomfloor,
 /area/misc/condo)

--- a/_maps/effigy/templates/condos/manor_hall.dmm
+++ b/_maps/effigy/templates/condos/manor_hall.dmm
@@ -204,7 +204,7 @@
 /turf/open/floor/stone,
 /area/misc/condo)
 "Jn" = (
-/turf/closed/indestructible/binary,
+/turf/cordon,
 /area/misc/condo)
 "Nx" = (
 /turf/open/floor/carpet/orange,
@@ -226,9 +226,6 @@
 /obj/effect/light_emitter/fake_outdoors,
 /turf/open/misc/grass/jungle/station,
 /area/misc/condo)
-"RI" = (
-/turf/template_noop,
-/area/template_noop)
 "SB" = (
 /turf/closed/indestructible/weeb,
 /area/misc/condo)
@@ -315,10 +312,10 @@
 /area/misc/condo)
 
 (1,1,1) = {"
-RI
-RI
-RI
-RI
+Jn
+Jn
+Jn
+Jn
 IB
 IB
 IB
@@ -331,9 +328,9 @@ gf
 Jn
 "}
 (2,1,1) = {"
-RI
-RI
-RI
+Jn
+Jn
+Jn
 IB
 IB
 ci
@@ -347,8 +344,8 @@ gf
 zp
 "}
 (3,1,1) = {"
-RI
-RI
+Jn
+Jn
 IB
 IB
 ci
@@ -363,7 +360,7 @@ su
 gf
 "}
 (4,1,1) = {"
-RI
+Jn
 IB
 IB
 ci
@@ -379,7 +376,7 @@ SI
 SB
 "}
 (5,1,1) = {"
-RI
+Jn
 IB
 ci
 ci
@@ -491,7 +488,7 @@ ql
 gf
 "}
 (12,1,1) = {"
-RI
+Jn
 IB
 ci
 DQ
@@ -507,7 +504,7 @@ SE
 SB
 "}
 (13,1,1) = {"
-RI
+Jn
 IB
 IB
 ci
@@ -523,8 +520,8 @@ Od
 SB
 "}
 (14,1,1) = {"
-RI
-RI
+Jn
+Jn
 IB
 IB
 ci
@@ -539,9 +536,9 @@ dV
 gf
 "}
 (15,1,1) = {"
-RI
-RI
-RI
+Jn
+Jn
+Jn
 IB
 IB
 ci
@@ -555,10 +552,10 @@ gf
 gf
 "}
 (16,1,1) = {"
-RI
-RI
-RI
-RI
+Jn
+Jn
+Jn
+Jn
 IB
 IB
 IB
@@ -568,5 +565,5 @@ gf
 SU
 gf
 gf
-RI
+Jn
 "}

--- a/_maps/effigy/templates/condos/medieval_bog.dmm
+++ b/_maps/effigy/templates/condos/medieval_bog.dmm
@@ -188,8 +188,8 @@
 /turf/open/misc/dirt/station,
 /area/misc/condo)
 "GA" = (
-/turf/template_noop,
-/area/template_noop)
+/turf/cordon,
+/area/misc/condo)
 "HS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10

--- a/_maps/effigy/templates/condos/necropolis.dmm
+++ b/_maps/effigy/templates/condos/necropolis.dmm
@@ -82,8 +82,8 @@
 /turf/open/indestructible/boss/air,
 /area/misc/condo)
 "nw" = (
-/turf/template_noop,
-/area/template_noop)
+/turf/cordon,
+/area/misc/condo)
 "pV" = (
 /obj/structure/chair/stool/directional/east,
 /obj/effect/turf_decal/siding/wood{
@@ -235,9 +235,6 @@
 "Be" = (
 /obj/structure/flora/rock/style_2,
 /turf/open/floor/fakebasalt,
-/area/misc/condo)
-"Bz" = (
-/turf/closed/indestructible/binary,
 /area/misc/condo)
 "BC" = (
 /obj/structure/stone_tile/block{
@@ -457,10 +454,10 @@ ux
 ux
 ux
 ux
-Bz
-Bz
-Bz
-Bz
+nw
+nw
+nw
+nw
 "}
 (2,1,1) = {"
 gk

--- a/_maps/effigy/templates/condos/northstar_dorms_four.dmm
+++ b/_maps/effigy/templates/condos/northstar_dorms_four.dmm
@@ -40,7 +40,7 @@
 /turf/open/floor/iron/dark,
 /area/misc/condo)
 "t" = (
-/turf/closed/indestructible/binary,
+/turf/cordon,
 /area/misc/condo)
 "u" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -48,9 +48,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/misc/condo)
-"w" = (
-/turf/template_noop,
-/area/template_noop)
 "B" = (
 /obj/structure/sink/directional/east,
 /obj/structure/mirror/directional/west,
@@ -100,7 +97,7 @@ X
 B
 D
 a
-w
+t
 "}
 (3,1,1) = {"
 a
@@ -108,7 +105,7 @@ n
 P
 P
 S
-w
+t
 "}
 (4,1,1) = {"
 a

--- a/_maps/effigy/templates/condos/ocean_view.dmm
+++ b/_maps/effigy/templates/condos/ocean_view.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/template_noop,
-/area/template_noop)
+/turf/cordon,
+/area/misc/condo)
 "b" = (
 /obj/structure/dresser,
 /turf/open/floor/iron/dark/diagonal,

--- a/_maps/effigy/templates/condos/planar_soil.dmm
+++ b/_maps/effigy/templates/condos/planar_soil.dmm
@@ -103,8 +103,8 @@
 /turf/open/misc/grass/jungle/station,
 /area/misc/condo)
 "X" = (
-/turf/template_noop,
-/area/template_noop)
+/turf/cordon,
+/area/misc/condo)
 "Y" = (
 /turf/closed/indestructible/rock,
 /area/misc/condo)

--- a/_maps/effigy/templates/condos/sigma_lux_dorm.dmm
+++ b/_maps/effigy/templates/condos/sigma_lux_dorm.dmm
@@ -16,9 +16,6 @@
 /obj/structure/fluff/fake_vent,
 /turf/open/floor/iron/white/diagonal,
 /area/misc/condo)
-"bn" = (
-/turf/template_noop,
-/area/template_noop)
 "fv" = (
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
@@ -293,7 +290,7 @@
 /turf/open/floor/iron/diagonal,
 /area/misc/condo)
 "GF" = (
-/turf/closed/indestructible/binary,
+/turf/cordon,
 /area/misc/condo)
 "Hj" = (
 /obj/effect/turf_decal/siding/wood{
@@ -417,10 +414,10 @@
 /area/misc/condo)
 
 (1,1,1) = {"
-bn
-bn
-bn
-bn
+GF
+GF
+GF
+GF
 me
 me
 me
@@ -432,7 +429,7 @@ me
 GF
 "}
 (2,1,1) = {"
-bn
+GF
 Zm
 me
 me
@@ -492,7 +489,7 @@ aN
 hi
 "}
 (6,1,1) = {"
-bn
+GF
 me
 me
 me
@@ -507,9 +504,9 @@ aN
 yd
 "}
 (7,1,1) = {"
-bn
-bn
-bn
+GF
+GF
+GF
 me
 vA
 HZ
@@ -522,8 +519,8 @@ me
 wi
 "}
 (8,1,1) = {"
-bn
-bn
+GF
+GF
 me
 me
 Ao
@@ -537,8 +534,8 @@ Mr
 Vl
 "}
 (9,1,1) = {"
-bn
-bn
+GF
+GF
 me
 Hj
 gT
@@ -552,8 +549,8 @@ me
 Dv
 "}
 (10,1,1) = {"
-bn
-bn
+GF
+GF
 me
 FV
 Ly
@@ -567,14 +564,14 @@ me
 Er
 "}
 (11,1,1) = {"
-bn
-bn
+GF
+GF
 me
 me
 me
 me
-bn
-bn
+GF
+GF
 me
 Gs
 Hw

--- a/_maps/effigy/templates/condos/station_arrivals.dmm
+++ b/_maps/effigy/templates/condos/station_arrivals.dmm
@@ -61,8 +61,8 @@
 /turf/open/floor/iron/smooth_large,
 /area/misc/condo)
 "jr" = (
-/turf/template_noop,
-/area/template_noop)
+/turf/cordon,
+/area/misc/condo)
 "kQ" = (
 /obj/structure/sign/poster/contraband/syndicate_pistol/directional/north,
 /turf/open/floor/plating,

--- a/_maps/effigy/templates/condos/xeno_resin.dmm
+++ b/_maps/effigy/templates/condos/xeno_resin.dmm
@@ -41,8 +41,8 @@
 /turf/open/floor/iron,
 /area/misc/condo)
 "Q" = (
-/turf/template_noop,
-/area/template_noop)
+/turf/cordon,
+/area/misc/condo)
 "S" = (
 /obj/structure/alien/weeds,
 /obj/structure/alien/egg/fake,

--- a/local/code/datums/loadouts/loadout_datum_neck.dm
+++ b/local/code/datums/loadouts/loadout_datum_neck.dm
@@ -258,4 +258,4 @@ GLOBAL_LIST_INIT(loadout_necks, generate_loadout_items(/datum/loadout_item/neck)
 /datum/loadout_item/neck/link_scryer
 	name = "MODlink Scryer"
 	item_path = /obj/item/clothing/neck/link_scryer
-	additional_tooltip_contents = ("UNLINKED - Needs to be synced to the network by robotics.")
+	additional_tooltip_contents = list("UNLINKED - Needs to be synced to the network by robotics.")


### PR DESCRIPTION
:cl:
add: Sigma Octantis And Rimpoint have been spruced up more.
fix: Neck loadout items are selectable again.
fix: Space no longer bleeds into your planetside condo.
/:cl:
