### PR TITLE
Fix a few RimPoint GPS destinations

### DIFF
--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -22715,7 +22715,9 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/effect/landmark/navigate_destination,
+/obj/effect/landmark/navigate_destination{
+	location = "Studio Control Room"
+	},
 /turf/open/floor/wood/large,
 /area/station/service/studio)
 "ilF" = (
@@ -31084,7 +31086,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/landmark/navigate_destination,
+/obj/effect/landmark/navigate_destination{
+	location = "Service Hallway"
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/hallway/secondary/service)
 "los" = (
@@ -31249,7 +31253,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/landmark/navigate_destination,
+/obj/effect/landmark/navigate_destination{
+	location = "Theater"
+	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/theater)
 "lro" = (
@@ -32152,7 +32158,9 @@
 "lKU" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/landmark/navigate_destination,
+/obj/effect/landmark/navigate_destination{
+	location = "Cryogenics Quarters"
+	},
 /turf/open/floor/iron/textured_large,
 /area/station/commons/cryo)
 "lLa" = (


### PR DESCRIPTION
## About The Pull Request

var edit the GPS destination map helpers for the Studio, Service Hall, Cryo, and the Theater to have locations set.

## Why It's Good For The Game

autonaming for GPS destinations is broken in tandem with airlock autoname helpers and so you just get GPS destinations named things like "Public glass Airlock".

## Changelog

:cl:
fix: fixed some GPS destinations on RimPoint being broken
/:cl: