### PR TITLE
Fix modsuits being unremovable

### DIFF
--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -305,6 +305,10 @@
 
 		return
 	// EffigyEdit Add End
+	if(!wearer.incapacitated)
+		var/atom/movable/screen/inventory/hand/ui_hand = over
+		if(wearer.putItemFromInventoryInHandIfPossible(src, ui_hand.held_index))
+			add_fingerprint(usr)
 
 /obj/item/mod/control/wrench_act(mob/living/user, obj/item/wrench)
 	if(seconds_electrified && get_charge() && shock(user))


### PR DESCRIPTION
## About The Pull Request

Restores unintentionally removed code that handled removing modsuits from your back. This along with the effigy edit above it can be removed in the next upstream merge as tg added a check for removing the suit when it's active, but for now this will solve the immediate problem.

## Why It's Good For The Game

Fixes #985

## Changelog

:cl:
fix: fixed being unable to remove modsuits from your back slot.
/:cl:
