### PR TITLE
Rimpoint - Library Cameras; Newscasters

### DIFF
--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -7126,6 +7126,7 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Medbay - Psychologist's Office"
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/medical/psychology)
 "cCi" = (
@@ -9010,6 +9011,10 @@
 	},
 /turf/open/floor/plating,
 /area/taeloth/underground)
+"dmi" = (
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/catwalk_floor/iron_white,
+/area/station/science/xenobiology)
 "dmB" = (
 /obj/effect/baseturf_helper/reinforced_plating/ceiling,
 /turf/closed/wall/r_wall,
@@ -9056,6 +9061,7 @@
 /obj/item/book/manual/wiki/medicine,
 /obj/item/clothing/neck/stethoscope,
 /obj/item/wrench/medical,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron/smooth_large,
 /area/station/medical/treatment_center)
 "doP" = (
@@ -11144,6 +11150,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/commissary)
 "ebc" = (
@@ -11282,6 +11289,7 @@
 "edw" = (
 /obj/machinery/pdapainter/research,
 /obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white/diagonal,
 /area/station/command/heads_quarters/rd)
 "edy" = (
@@ -11527,6 +11535,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood/tile,
 /area/station/science/breakroom)
 "eih" = (
@@ -12899,6 +12908,7 @@
 /area/station/maintenance/department/crew_quarters/dorms)
 "eGx" = (
 /obj/machinery/vending/wardrobe/robo_wardrobe,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/glass/plasma,
 /area/station/science/robotics)
 "eGJ" = (
@@ -16100,6 +16110,7 @@
 	pixel_y = 10
 	},
 /obj/item/stock_parts/power_store/cell/high,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/small,
 /area/station/science)
 "fNY" = (
@@ -17754,6 +17765,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood/large,
 /area/station/medical/medbay/lobby/aft)
 "gqO" = (
@@ -19964,6 +19976,7 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 10
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
@@ -27592,6 +27605,7 @@
 /obj/effect/turf_decal/siding/wideplating_new/light{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
 "jXF" = (
@@ -28434,6 +28448,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/ai)
 "knc" = (
@@ -30692,6 +30707,7 @@
 /area/station/cargo/bitrunning/den)
 "lgm" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/medical/chem_storage)
 "lgw" = (
@@ -34548,6 +34564,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/genetics)
 "mCw" = (
@@ -36724,6 +36741,7 @@
 /obj/item/mmi,
 /obj/item/mmi,
 /obj/item/mmi,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/diagonal,
 /area/station/science/robotics/augments)
 "nul" = (
@@ -38040,6 +38058,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 6
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/storage)
 "nSo" = (
@@ -44131,6 +44150,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating_new/corner,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/white/small,
 /area/station/medical/pharmacy)
 "qhE" = (
@@ -50088,6 +50108,7 @@
 	pixel_y = 6
 	},
 /obj/item/stack/sheet/iron/twenty,
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron/small,
 /area/station/science)
 "sjy" = (
@@ -53842,6 +53863,22 @@
 	dir = 4
 	},
 /area/station/commons/storage/primary)
+"tBl" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/white/side{
+	dir = 6
+	},
+/area/station/science)
 "tBu" = (
 /obj/structure/stairs/south,
 /obj/effect/turf_decal/stripes/line{
@@ -54553,6 +54590,7 @@
 /obj/structure/railing/corner/end{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/medical/virology)
 "tQf" = (
@@ -54713,6 +54751,7 @@
 "tTj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/smooth_large,
 /area/station/medical/treatment_center)
 "tTl" = (
@@ -57349,6 +57388,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "uOG" = (
@@ -62891,6 +62931,7 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "wOz" = (
@@ -64754,6 +64795,10 @@
 	},
 /turf/open/floor/stone,
 /area/taeloth/nearstation/gateway)
+"xxi" = (
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron,
+/area/station/medical/chemistry)
 "xxk" = (
 /obj/structure/sign/directions/security/directional/south{
 	pixel_y = -24;
@@ -91092,7 +91137,7 @@ jri
 lDm
 qcu
 cei
-dSY
+dmi
 kfM
 ody
 iPT
@@ -94416,7 +94461,7 @@ kuj
 kbH
 fUY
 xCe
-sqo
+tBl
 jjz
 xfR
 qBZ
@@ -157349,7 +157394,7 @@ xnr
 xnr
 xnr
 xkZ
-dob
+xxi
 dob
 xWb
 wvM

--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -292,6 +292,9 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/camera/directional/west{
+	c_tag = "Service - Library; Second Deck; Southwest"
+	},
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
 "agu" = (
@@ -10777,6 +10780,21 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/misc/dirt/jungle,
 /area/taeloth/nearstation/service_crossway)
+"dSR" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Service - Library; Second Deck; North"
+	},
+/turf/open/floor/glass/reinforced,
+/area/station/service/library)
 "dSS" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -33101,8 +33119,10 @@
 /turf/open/floor/stone,
 /area/taeloth/nearstation/restroom_roof)
 "mdy" = (
-/obj/machinery/digital_clock/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/camera/directional/north{
+	c_tag = "Service - Library; Second Deck; Centre"
+	},
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
 "mdz" = (
@@ -33149,6 +33169,7 @@
 /area/station/hallway/secondary/recreation)
 "mes" = (
 /obj/machinery/bookbinder,
+/obj/machinery/digital_clock/directional/north,
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
 "met" = (
@@ -177116,7 +177137,7 @@ jaM
 ddz
 fAH
 gAj
-dbA
+dSR
 dbA
 dbA
 dbA

--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -3581,6 +3581,7 @@
 /turf/closed/wall/mineral/iron,
 /area/station/commons/toilet/restrooms)
 "bqu" = (
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "bqC" = (
@@ -6969,6 +6970,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "czy" = (
@@ -13896,6 +13898,20 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating/reinforced,
 /area/station/maintenance/department/science)
+"eYd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/catwalk_floor/iron,
+/area/station/engineering/hallway)
 "eYv" = (
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/storage)
@@ -15640,6 +15656,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"fCu" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/security/execution/education)
 "fCB" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Engineering - Atmospherics, Southeast";
@@ -17798,6 +17821,14 @@
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
+"grg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/recreation)
 "grq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -20244,6 +20275,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
 "hnv" = (
@@ -24068,6 +24100,7 @@
 "iJm" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "iJD" = (
@@ -28790,6 +28823,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "kty" = (
@@ -30466,6 +30500,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/security_officer,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/security/lockers)
 "lbF" = (
@@ -30599,6 +30634,7 @@
 	pixel_y = 7;
 	pixel_x = -8
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/theater)
 "let" = (
@@ -31508,6 +31544,7 @@
 /turf/open/floor/iron/dark/small,
 /area/station/cargo/storage)
 "lvw" = (
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
 "lvx" = (
@@ -31735,6 +31772,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/mineral/plastitanium,
 /area/station/command/heads_quarters/hos)
 "lAU" = (
@@ -32963,6 +33001,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "maW" = (
@@ -33657,6 +33696,7 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/command/heads_quarters/hop)
 "mmr" = (
@@ -37946,6 +37986,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"nPX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "nPZ" = (
 /obj/structure/railing/corner,
 /turf/open/floor/glass/reinforced,
@@ -38491,6 +38538,7 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/power_store/cell/high,
 /obj/effect/turf_decal/tile/dark_blue,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "ocm" = (
@@ -38843,6 +38891,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "oje" = (
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/glass/reinforced,
 /area/station/ai_monitored/command/nuke_storage)
 "ojf" = (
@@ -40062,6 +40111,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "oIT" = (
@@ -42751,6 +42801,10 @@
 	dir = 1
 	},
 /area/station/commons/storage/primary)
+"pGW" = (
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron,
+/area/station/security/brig)
 "pHb" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/folder/red,
@@ -43436,6 +43490,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/wood,
 /area/station/engineering/hallway)
 "pTM" = (
@@ -43693,6 +43748,7 @@
 	},
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "qaB" = (
@@ -44143,6 +44199,7 @@
 /area/station/medical/medbay/lobby/fore)
 "qgV" = (
 /obj/structure/table/wood,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain)
 "qhz" = (
@@ -49221,6 +49278,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/wood/large,
 /area/station/service/lawoffice)
 "rUo" = (
@@ -50610,6 +50668,7 @@
 "srf" = (
 /obj/machinery/computer/records/medical,
 /obj/effect/turf_decal/siding/wood,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood/large,
 /area/station/security/detectives_office)
 "srl" = (
@@ -55741,6 +55800,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/carpet/executive,
 /area/station/command/meeting_room/council)
 "ukJ" = (
@@ -61253,6 +61313,13 @@
 	},
 /turf/open/floor/wood/large,
 /area/taeloth)
+"wiN" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 1
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "wiU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -63865,6 +63932,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/cafeteria)
 "xfe" = (
@@ -64484,6 +64552,11 @@
 /obj/structure/flora/tree/jungle/style_random,
 /turf/open/misc/grass/jungle,
 /area/taeloth/nearstation/dormitory_concourse/crew_facilities)
+"xqt" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/glass,
+/area/station/service/hydroponics)
 "xqO" = (
 /turf/open/floor/iron/diagonal,
 /area/station/engineering/atmos/hfr_room)
@@ -64641,6 +64714,7 @@
 	pixel_x = 6
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/wood,
 /area/station/service/theater)
 "xtP" = (
@@ -65358,6 +65432,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
+"xEk" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/dark/small,
+/area/station/security/courtroom)
 "xEn" = (
 /obj/machinery/door/airlock/engineering,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/aux_base,
@@ -88996,7 +89077,7 @@ gXq
 aiV
 dAg
 jwV
-dvi
+xEk
 ojM
 vMS
 vMS
@@ -90261,7 +90342,7 @@ rCE
 rCE
 xUc
 xUc
-upj
+wiN
 mVB
 jQQ
 xNb
@@ -94895,7 +94976,7 @@ aam
 qmA
 dRe
 iqx
-nGC
+pGW
 cya
 nGC
 kmu
@@ -101938,7 +102019,7 @@ nuT
 pNv
 rnx
 uSH
-rEo
+eYd
 aoM
 aoM
 aoM
@@ -107508,7 +107589,7 @@ lvs
 jKI
 sBD
 vXL
-jPA
+nPX
 ylf
 jPA
 uGU
@@ -110136,7 +110217,7 @@ nDP
 sml
 tKz
 pjT
-jCe
+xqt
 jCe
 jCe
 isj
@@ -113960,7 +114041,7 @@ vMc
 rLC
 gTg
 xNs
-rLC
+grg
 iFi
 oLn
 jrH
@@ -157855,7 +157936,7 @@ dOg
 oRo
 ryD
 vsO
-ryD
+fCu
 sjj
 vEX
 qen


### PR DESCRIPTION
:cl:
fix: The AI can now see the second floor of the library on Rimpoint. Additionally; newscasters have been spread around where they should've been.
/:cl:
