### PR TITLE
Sigma - Fixes The Medbay Bin + Adds More Holopads

### DIFF
--- a/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
+++ b/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
@@ -9399,6 +9399,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/medical/medbay/central)
 "ceu" = (
@@ -16629,6 +16630,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth_large,
 /area/station/medical/surgery/theatre)
 "dNi" = (
@@ -19605,6 +19609,9 @@
 /obj/machinery/duct/supply,
 /obj/machinery/duct/waste,
 /obj/effect/landmark/start/paramedic,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/smooth_large,
 /area/station/medical/medbay/central)
 "evz" = (
@@ -31618,6 +31625,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth_large,
 /area/station/medical/medbay/central)
 "hdW" = (
@@ -35193,6 +35203,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "hWp" = (
@@ -35491,6 +35504,7 @@
 "iaF" = (
 /obj/machinery/duct/supply,
 /obj/machinery/duct/waste,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/smooth_large,
 /area/station/medical/medbay/central)
 "iaO" = (
@@ -40078,6 +40092,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth_large,
 /area/station/medical/medbay/central)
 "jfd" = (
@@ -44520,6 +44537,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "kfQ" = (
@@ -68701,6 +68719,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/duct/supply,
 /obj/machinery/duct/waste,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/smooth_large,
 /area/station/medical/surgery/theatre)
 "pPI" = (
@@ -69707,6 +69726,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "qcq" = (
@@ -74800,6 +74820,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "rji" = (
@@ -78475,6 +78498,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wideplating_new/light/corner,
+/obj/machinery/holopad,
 /turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/aft)
 "sab" = (
@@ -78627,6 +78651,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "sci" = (
@@ -86260,6 +86285,7 @@
 "tVP" = (
 /obj/machinery/duct/supply,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
 /turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "tVT" = (
@@ -90200,8 +90226,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -93121,6 +93147,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron/smooth_large,
 /area/station/medical/surgery/theatre)
 "vEd" = (
@@ -95560,6 +95589,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "wfC" = (


### PR DESCRIPTION
:cl:
fix: Sigma Octantis no longer has a bin that just breaks the floor and does nothing else. Oops.
/:cl:
