### PR TITLE
Fix communication hotkeys conflicting with all others

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1024,26 +1024,6 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 					movement_keys[key] = WEST
 				if("South")
 					movement_keys[key] = SOUTH
-				//EFFIGY ADDITION START
-				if(LOOC_CHANNEL)
-					var/looc = tgui_say_create_open_command(LOOC_CHANNEL)
-					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=[looc]")
-				if(WHIS_CHANNEL)
-					var/whis = tgui_say_create_open_command(WHIS_CHANNEL)
-					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=[whis]")
-				//EFFIGY ADDITION END
-				if(SAY_CHANNEL)
-					var/say = tgui_say_create_open_command(SAY_CHANNEL)
-					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=[say]")
-				if(RADIO_CHANNEL)
-					var/radio = tgui_say_create_open_command(RADIO_CHANNEL)
-					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=[radio]")
-				if(ME_CHANNEL)
-					var/me = tgui_say_create_open_command(ME_CHANNEL)
-					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=[me]")
-				if(OOC_CHANNEL)
-					var/ooc = tgui_say_create_open_command(OOC_CHANNEL)
-					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=[ooc]")
 				if(ADMIN_CHANNEL)
 					if(holder)
 						var/asay = tgui_say_create_open_command(ADMIN_CHANNEL)

--- a/local/code/datums/keybinding/communication.dm
+++ b/local/code/datums/keybinding/communication.dm
@@ -4,8 +4,22 @@
 	full_name = "Local OOC (LOOC)"
 	keybind_signal = COMSIG_KB_CLIENT_LOOC_DOWN
 
+/datum/keybinding/client/communication/looc/down(client/user)
+	. = ..()
+	if(.)
+		return
+	winset(user, null, "command=[user.tgui_say_create_open_command(LOOC_CHANNEL)]")
+	return TRUE
+
 /datum/keybinding/client/communication/whisper
 	hotkey_keys = list("Y")
 	name = WHIS_CHANNEL
 	full_name = "IC Whisper"
 	keybind_signal = COMSIG_KB_CLIENT_WHISPER_DOWN
+
+/datum/keybinding/client/communication/whisper/down(client/user)
+	. = ..()
+	if(.)
+		return
+	winset(user, null, "command=[user.tgui_say_create_open_command(WHIS_CHANNEL)]")
+	return TRUE


### PR DESCRIPTION
## About The Pull Request

Fixes a bug wherein binding a combination hotkey that involves a key used in a communication hotkey causes both actions to trigger when the combination hotkey is pressed e.g. L on LOOC and CtrlL on *laugh causes you to both laugh and open the LOOC menu when you press CtrlL.

## Why It's Good For The Game

Bug fix, brings relevant code to parity with upstream (tg uses the `/datum/keybinding` overrides instead of the switch case in `client_procs.dm` now)

## Changelog

:cl:
fix: Fixes communication hotkeys conflicting with other hotkeys that use that button.
/:cl:

