### PR TITLE
Flip Sigma Octantis tank compressor turnways

### DIFF
--- a/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
+++ b/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
@@ -49820,7 +49820,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "lpW" = (
-/obj/machinery/atmospherics/components/binary/tank_compressor,
+/obj/machinery/atmospherics/components/binary/tank_compressor{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},


### PR DESCRIPTION
## About The Pull Request

Rotate the tank compressor in Sigma Octantis ordnance because it was backwards and didn't work

## Why It's Good For The Game

Gotta do those gas shells

## Changelog

:cl:
fix: the tank compressor in Sigma Octantis ordnance should work now.
/:cl:

