### PR TITLE
Add box of gas miner beacons to CE's locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -19,6 +19,7 @@
 	new /obj/item/storage/photo_album/ce(src)
 	new /obj/item/storage/box/skillchips/engineering(src)
 	new /obj/item/storage/box/stickers/chief_engineer(src)
+	new /obj/item/storage/box/gas_miner_beacons(src) // EffigyEdit Addition - Gas miner beacons
 
 /obj/structure/closet/secure_closet/engineering_chief/populate_contents_immediate()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Add a box with two gas miner beacons to the CE's locker.

## Why It's Good For The Game

🥺👉👈 (having these round start is really handy for Projects)

## Changelog

:cl:
add: The CE now starts with a box of two gas miner beacons in their locker.
/:cl:
