### PR TITLE
Adds Flatpacks to each map roundstart

### DIFF
--- a/_maps/effigy/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/effigy/map_files/FoxHoleStation/foxholestation.dmm
@@ -7016,7 +7016,6 @@
 /area/station/maintenance/aft/greater)
 "dLP" = (
 /obj/effect/turf_decal/siding/wideplating_new,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -22057,14 +22056,15 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/interrogation)
 "mjE" = (
-/obj/machinery/modular_computer/preset/engineering{
-	dir = 8
-	},
+/obj/structure/rack,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/east,
-/obj/structure/cable,
+/obj/item/flatpack,
+/obj/item/multitool{
+	pixel_x = 7
+	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/engineering/storage)
 "mkf" = (

--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -67985,14 +67985,16 @@
 /turf/open/floor/plating,
 /area/station/science/genetics)
 "ycL" = (
-/obj/machinery/modular_computer/preset/civilian{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
 /obj/machinery/camera/directional/south{
 	c_tag = "Engineering - Hallway, Centre"
+	},
+/obj/item/flatpack,
+/obj/structure/rack,
+/obj/item/multitool{
+	pixel_x = 7
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)

--- a/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
+++ b/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
@@ -54687,6 +54687,11 @@
 /obj/effect/turf_decal/trimline/yellow/line,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/rack,
+/obj/item/flatpack,
+/obj/item/multitool{
+	pixel_x = 7
+	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "mAj" = (


### PR DESCRIPTION
:cl:
add: Flatpacks have been added to all Effigy-specific maps. Oops.
/:cl:
