### PR TITLE
[WEBEDIT] Changes scrap pile description

### DIFF
--- a/local/code/game/objects/structures/scrap.dm
+++ b/local/code/game/objects/structures/scrap.dm
@@ -1,6 +1,6 @@
 /obj/structure/scrap
 	name = "scrap pile"
-	desc = "A pile of debris, thrown in a loose pile. There may be valuables, ore, or just junk in it."
+	desc = "A pile of debris, thrown in a loose pile."
 	icon = 'local/icons/obj/scrap.dmi'
 	icon_state = "scrap"
 	anchored = TRUE


### PR DESCRIPTION
the description for scrap piles incorrectly referenced their old loot pool (you have to remember salvaging is hacked together from a few different mechanics' shambling husks). this corrects that

:cl:
spellcheck: scrap no longer insinuates it contains ore.
/:cl:
